### PR TITLE
Add group functionality to subscribers

### DIFF
--- a/pubsubx/inmemory.go
+++ b/pubsubx/inmemory.go
@@ -58,6 +58,13 @@ func (ps *memoryPubSub) Publish(topic string, messages ...*message.Message) erro
 	return ps.pubsubchan.Publish(topic, messages...)
 }
 
+func (ps *memoryPubSub) SetupSubscriber() func(group string) (Subscriber, error) {
+	// The in-memory pubsub doesn't support grouping.
+	return func(group string) (Subscriber, error) {
+		return ps, nil
+	}
+}
+
 func (ps *memoryPubSub) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
 	return ps.pubsubchan.Subscribe(ctx, topic)
 }

--- a/pubsubx/kafka.go
+++ b/pubsubx/kafka.go
@@ -23,16 +23,22 @@ func SetupKafkaPublisher(l *logrusx.Logger, c *Config) (Publisher, error) {
 }
 
 // TODO: add subscriber configs
-func SetupKafkaSubscriber(l *logrusx.Logger, c *Config) (Subscriber, error) {
+func SetupKafkaSubscriber(l *logrusx.Logger, c *Config, group string) (Subscriber, error) {
 	saramaSubscriberConfig := kafka.DefaultSaramaSubscriberConfig()
 	saramaSubscriberConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 
+	conf := kafka.SubscriberConfig{
+		Brokers:               c.Providers.Kafka.Brokers,
+		Unmarshaler:           kafka.DefaultMarshaler{},
+		OverwriteSaramaConfig: saramaSubscriberConfig,
+	}
+
+	if group != "" {
+		conf.ConsumerGroup = group
+	}
+
 	subscriber, err := kafka.NewSubscriber(
-		kafka.SubscriberConfig{
-			Brokers:               c.Providers.Kafka.Brokers,
-			Unmarshaler:           kafka.DefaultMarshaler{},
-			OverwriteSaramaConfig: saramaSubscriberConfig,
-		},
+		conf,
 		NewLogrusLogger(l.Logger),
 	)
 	if err != nil {

--- a/pubsubx/pubsub.go
+++ b/pubsubx/pubsub.go
@@ -8,7 +8,8 @@ import (
 type PubSub interface {
 	Publisher() Publisher
 	Subscriber(group string) (Subscriber, error)
-	CloseAllSubscribers() error
+	// CLoses all publishers and subscribers.
+	Close() error
 }
 
 type pubSub struct {
@@ -77,7 +78,7 @@ func (ps *pubSub) Subscriber(group string) (Subscriber, error) {
 	return ps.subscriber(group)
 }
 
-func (ps *pubSub) CloseAllSubscribers() error {
+func (ps *pubSub) Close() error {
 	errors := []error{}
 	for _, s := range ps.subs {
 		if err := s.Close(); err != nil {
@@ -87,6 +88,12 @@ func (ps *pubSub) CloseAllSubscribers() error {
 
 	if len(errors) > 0 {
 		return errors[0]
+	}
+
+	err := ps.publisher.Close()
+
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Abstract subscribers grouping so we don't depend on kafka directly.

Tried with alpha tag `v0.0.15-alpha`.