### PR TITLE
feat: migrate new error to error with format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       
       - name: Lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       
       - name: Lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          args: --timeout 2m
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: --timeout=5m
 
       - name: Test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,6 @@ jobs:
         env:
           ARANGO_URL: 'http://localhost:${{ job.services.arangodb.ports[8529] }}'
           ELASTICSEARCH_URL: 'http://localhost:${{ job.services.elasticsearch.ports[9200] }}'
-        run: go test $(go list ./... | grep -v /provider_watch_test/)
+        run: go test -skip TestProviderReload ./...
 
       

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -116,7 +116,7 @@ func compareLsof(t *testing.T, file, atStart, expected string) {
 	assert.True(t, e < a+deviation && e > a-deviation, "\n\t%s\n\t%s", atStart, lsof(t, file))
 }
 
-func TestReload(t *testing.T) {
+func TestProviderReload(t *testing.T) {
 	setup := func(t *testing.T, cf *os.File, c chan<- struct{}, modifiers ...OptionModifier) (*Provider, *logrusx.Logger) {
 		l := logrusx.New("configx", "test")
 		ctx, cancel := context.WithCancel(context.Background())

--- a/errorx/error.go
+++ b/errorx/error.go
@@ -16,6 +16,8 @@ type CliniaError struct {
 	OriginalError error // Not returned to clients
 }
 
+var _ error = (*CliniaError)(nil)
+
 type CliniaRetryableError = CliniaError
 
 func (e CliniaError) Error() string {
@@ -76,6 +78,91 @@ func IsFailedPreconditionError(e error) bool {
 	return mE.Type == ErrorTypeFailedPrecondition
 }
 
+func IsAlreadyExistsError(e error) bool {
+	mE, ok := e.(CliniaError)
+	if !ok {
+		return false
+	}
+
+	return mE.Type == ErrorTypeAlreadyExists
+}
+
+func IsInvalidFormatError(e error) bool {
+	mE, ok := e.(CliniaError)
+	if !ok {
+		return false
+	}
+
+	return mE.Type == ErrorTypeInvalidFormat
+}
+
+func IsUnsupportedError(e error) bool {
+	mE, ok := e.(CliniaError)
+	if !ok {
+		return false
+	}
+
+	return mE.Type == ErrorTypeUnsupported
+}
+
+func IsInternalError(e error) bool {
+	mE, ok := e.(CliniaError)
+	if !ok {
+		return false
+	}
+
+	return mE.Type == ErrorTypeInternal
+}
+
+// InternalErrorf creates a CliniaError with type ErrorTypeInternal and a formatted message
+func InternalErrorf(format string, args ...interface{}) CliniaError {
+	return CliniaError{
+		Type:    ErrorTypeInternal,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// NotFoundErrorf creates a CliniaError with type ErrorTypeNotFound and a formatted message
+func NotFoundErrorf(format string, args ...interface{}) CliniaError {
+	return CliniaError{
+		Type:    ErrorTypeNotFound,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// UnsupportedErrorf creates a CliniaError with type ErrorTypeUnsupported and a formatted message
+func UnsupportedErrorf(format string, args ...interface{}) CliniaError {
+	return CliniaError{
+		Type:    ErrorTypeUnsupported,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// InvalidFormatErrorf creates a CliniaError with type ErrorTypeInvalidFormat and a formatted message
+func InvalidFormatErrorf(format string, args ...interface{}) CliniaError {
+	return CliniaError{
+		Type:    ErrorTypeInvalidFormat,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// FailedPreconditionErrorf creates a CliniaError with type ErrorTypeFailedPrecondition and a formatted message
+func FailedPreconditionErrorf(format string, args ...interface{}) CliniaError {
+	return CliniaError{
+		Type:    ErrorTypeFailedPrecondition,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// AlreadyExistsErrorf creates a CliniaError with type ErrorTypeAlreadyExists and a formatted message
+func AlreadyExistsErrorf(format string, args ...interface{}) CliniaError {
+	return CliniaError{
+		Type:    ErrorTypeAlreadyExists,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// Deprecated: use InternalErrorf instead
 func NewInternalError(e error) CliniaRetryableError {
 	return CliniaRetryableError{
 		Type:          ErrorTypeInternal,
@@ -91,6 +178,7 @@ func NewEnumOutOfRangeError(actual string, expectedOneOf []string, enumName stri
 	}
 }
 
+// Deprecated: use NotFoundErrorf instead
 func NewNotFoundError(msg string, err error) CliniaError {
 	x := "Resource"
 	if msg != "" {
@@ -105,6 +193,7 @@ func NewNotFoundError(msg string, err error) CliniaError {
 	}
 }
 
+// Deprecated: use UnsupportedErrorf instead
 func NewUnsupportedError(message string) CliniaError {
 	return CliniaError{
 		Type:    ErrorTypeUnsupported,
@@ -112,6 +201,7 @@ func NewUnsupportedError(message string) CliniaError {
 	}
 }
 
+// Deprecated: use UnsupportedErrorf instead
 func NewInvalidFormatError(message string) CliniaError {
 	return CliniaError{
 		Type:    ErrorTypeInvalidFormat,
@@ -119,6 +209,7 @@ func NewInvalidFormatError(message string) CliniaError {
 	}
 }
 
+// Deprecated: use FailedPreconditionErrorf instead
 func NewFailedPreconditionError(message string) CliniaError {
 	return CliniaError{
 		Type:    ErrorTypeFailedPrecondition,
@@ -154,6 +245,7 @@ func NewUnsupportedTypeError[T1 any, T2 any](actual T1, expected T2) CliniaError
 	}
 }
 
+// Deprecated: use AlreadyExistsErrorf instead
 func NewAlreadyExistsError(message string) CliniaError {
 	return CliniaError{
 		Type:    ErrorTypeAlreadyExists,
@@ -161,6 +253,7 @@ func NewAlreadyExistsError(message string) CliniaError {
 	}
 }
 
+// Deprecated: use InternalErrorf instead
 func NewNotImplementedError(message string) CliniaError {
 	return CliniaError{
 		Type:    ErrorTypeNotImplemented,

--- a/errorx/error.go
+++ b/errorx/error.go
@@ -61,7 +61,7 @@ func IsCliniaError(e error) (*CliniaError, bool) {
 }
 
 func IsNotFoundError(e error) bool {
-	mE, ok := e.(CliniaError)
+	mE, ok := IsCliniaError(e)
 	if !ok {
 		return false
 	}
@@ -70,7 +70,7 @@ func IsNotFoundError(e error) bool {
 }
 
 func IsFailedPreconditionError(e error) bool {
-	mE, ok := e.(CliniaError)
+	mE, ok := IsCliniaError(e)
 	if !ok {
 		return false
 	}
@@ -79,7 +79,7 @@ func IsFailedPreconditionError(e error) bool {
 }
 
 func IsAlreadyExistsError(e error) bool {
-	mE, ok := e.(CliniaError)
+	mE, ok := IsCliniaError(e)
 	if !ok {
 		return false
 	}
@@ -88,7 +88,7 @@ func IsAlreadyExistsError(e error) bool {
 }
 
 func IsInvalidFormatError(e error) bool {
-	mE, ok := e.(CliniaError)
+	mE, ok := IsCliniaError(e)
 	if !ok {
 		return false
 	}
@@ -97,7 +97,7 @@ func IsInvalidFormatError(e error) bool {
 }
 
 func IsUnsupportedError(e error) bool {
-	mE, ok := e.(CliniaError)
+	mE, ok := IsCliniaError(e)
 	if !ok {
 		return false
 	}
@@ -106,7 +106,7 @@ func IsUnsupportedError(e error) bool {
 }
 
 func IsInternalError(e error) bool {
-	mE, ok := e.(CliniaError)
+	mE, ok := IsCliniaError(e)
 	if !ok {
 		return false
 	}

--- a/errorx/error_test.go
+++ b/errorx/error_test.go
@@ -23,4 +23,14 @@ func TestError(t *testing.T) {
 		_, ok := IsCliniaError(err)
 		assert.True(t, ok)
 	})
+
+	t.Run("should return is not found from stack", func(t *testing.T) {
+		err := errors.WithStack(NotFoundErrorf("test"))
+		assert.True(t, IsNotFoundError(err))
+	})
+
+	t.Run("should return is not found", func(t *testing.T) {
+		err := NotFoundErrorf("test")
+		assert.True(t, IsNotFoundError(err))
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clinia/x
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Shopify/sarama v1.38.1


### PR DESCRIPTION
I've added new function to accept a formatted message for all our relevant error types as well as marked our NewXError function as deprecated in favour of those new functions. I've also removed the `New` keyword as it does not follow golang standard for this specific use case