### PR TITLE
feat: [PROD-3870] Setup otelm and move tracer

### DIFF
--- a/configx/provider.go
+++ b/configx/provider.go
@@ -461,25 +461,25 @@ func (p *Provider) TracingConfig(serviceName string, attrs ...attribute.KeyValue
 	return &otelx.TracerConfig{
 		ResourceAttributes: attrs,
 		ServiceName:        p.StringF("tracing.service_name", serviceName),
-		TracerName:         p.String("tracing.tracer_name"),
+		Name:               p.String("tracing.name"),
 		Provider:           p.String("tracing.provider"),
 		Providers: otelx.TracerProvidersConfig{
 			Jaeger: otelx.JaegerConfig{
-				LocalAgentAddress: p.String("tracing.providers.jaeger.local_agent_address"),
+				LocalAgentAddress: p.String("tracer.providers.jaeger.local_agent_address"),
 				Sampling: otelx.JaegerSampling{
-					ServerURL: p.String("tracing.providers.jaeger.sampling.server_url"),
+					ServerURL: p.String("tracer.providers.jaeger.sampling.server_url"),
 				},
 			},
 			OTLP: otelx.OTLPConfig{
-				Protocol:  p.String("tracing.providers.otlp.protocol"),
-				ServerURL: p.String("tracing.providers.otlp.server_url"),
-				Insecure:  p.Bool("tracing.providers.otlp.insecure"),
+				Protocol:  p.String("tracer.providers.otlp.protocol"),
+				ServerURL: p.String("tracer.providers.otlp.server_url"),
+				Insecure:  p.Bool("tracer.providers.otlp.insecure"),
 				Sampling: otelx.OTLPSampling{
-					SamplingRatio: p.Float64("tracing.providers.otlp.sampling.sampling_ratio"),
+					SamplingRatio: p.Float64("tracer.providers.otlp.sampling.sampling_ratio"),
 				},
 			},
 			Stdout: otelx.StdoutConfig{
-				Pretty: p.Bool("tracing.providers.stdout.pretty"),
+				Pretty: p.Bool("tracer.providers.stdout.pretty"),
 			},
 		},
 	}

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -457,12 +457,12 @@ func (p *Provider) CORS(prefix string, defaults cors.Options) (cors.Options, boo
 	}, p.Bool(prefix + "cors.enabled")
 }
 
-func (p *Provider) TracingConfig(serviceName string, attrs ...attribute.KeyValue) *otelx.TracerConfig {
+func (p *Provider) TracerConfig(serviceName string, attrs ...attribute.KeyValue) *otelx.TracerConfig {
 	return &otelx.TracerConfig{
 		ResourceAttributes: attrs,
-		ServiceName:        p.StringF("tracing.service_name", serviceName),
-		Name:               p.String("tracing.name"),
-		Provider:           p.String("tracing.provider"),
+		ServiceName:        p.StringF("tracer.service_name", serviceName),
+		Name:               p.String("tracer.name"),
+		Provider:           p.String("tracer.provider"),
 		Providers: otelx.TracerProvidersConfig{
 			Jaeger: otelx.JaegerConfig{
 				LocalAgentAddress: p.String("tracer.providers.jaeger.local_agent_address"),

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -457,12 +457,13 @@ func (p *Provider) CORS(prefix string, defaults cors.Options) (cors.Options, boo
 	}, p.Bool(prefix + "cors.enabled")
 }
 
-func (p *Provider) TracingConfig(serviceName string, attrs ...attribute.KeyValue) *otelx.Config {
-	return &otelx.Config{
+func (p *Provider) TracingConfig(serviceName string, attrs ...attribute.KeyValue) *otelx.TracerConfig {
+	return &otelx.TracerConfig{
 		ResourceAttributes: attrs,
 		ServiceName:        p.StringF("tracing.service_name", serviceName),
+		TracerName:         p.String("tracing.tracer_name"),
 		Provider:           p.String("tracing.provider"),
-		Providers: otelx.ProvidersConfig{
+		Providers: otelx.TracerProvidersConfig{
 			Jaeger: otelx.JaegerConfig{
 				LocalAgentAddress: p.String("tracing.providers.jaeger.local_agent_address"),
 				Sampling: otelx.JaegerSampling{
@@ -483,6 +484,26 @@ func (p *Provider) TracingConfig(serviceName string, attrs ...attribute.KeyValue
 		},
 	}
 }
+
+// // TODO: Change source
+// func (p *Provider) MeterConfig(serviceName string, attrs ...attribute.KeyValue) *otelx.MeterConfig {
+// 	return &otelx.MeterConfig{
+// 		Provider: p.String("tracing.provider"),
+// 		Providers: otelx.MeterProvidersConfig{
+// 			OTLP: otelx.OTLPConfig{
+// 				Protocol:  p.String("tracing.providers.otlp.protocol"),
+// 				ServerURL: p.String("tracing.providers.otlp.server_url"),
+// 				Insecure:  p.Bool("tracing.providers.otlp.insecure"),
+// 				Sampling: otelx.OTLPSampling{
+// 					SamplingRatio: p.Float64("tracing.providers.otlp.sampling.sampling_ratio"),
+// 				},
+// 			},
+// 			Stdout: otelx.StdoutConfig{
+// 				Pretty: p.Bool("tracing.providers.stdout.pretty"),
+// 			},
+// 		},
+// 	}
+// }
 
 func (p *Provider) PubSubConfig() *pubsubx.Config {
 	return &pubsubx.Config{

--- a/configx/schema.go
+++ b/configx/schema.go
@@ -31,9 +31,12 @@ func newCompiler(schema []byte) (string, *jsonschema.Compiler, error) {
 	// DO NOT REMOVE THIS
 	compiler.ExtractAnnotations = true
 
-	if err := otelx.AddConfigSchema(compiler); err != nil {
+	if err := otelx.AddTracerConfigSchema(compiler); err != nil {
 		return "", nil, err
 	}
+	// if err := otelx.AddMeterConfigSchema(compiler); err != nil {
+	// 	return "", nil, err
+	// }
 	if err := logrusx.AddConfigSchema(compiler); err != nil {
 		return "", nil, err
 	}

--- a/otelx/config_test.go
+++ b/otelx/config_test.go
@@ -32,7 +32,7 @@ func TestConfigSchema(t *testing.T) {
 
 		conf := TracerConfig{
 			ServiceName: "Clinia X",
-			TracerName:  "X",
+			Name:        "X",
 			Provider:    "otel",
 			Providers: TracerProvidersConfig{
 				OTLP: OTLPConfig{

--- a/otelx/config_test.go
+++ b/otelx/config_test.go
@@ -28,12 +28,13 @@ const rootSchema = `{
 func TestConfigSchema(t *testing.T) {
 	t.Run("func=AddConfigSchema", func(t *testing.T) {
 		c := jsonschema.NewCompiler()
-		require.NoError(t, AddConfigSchema(c))
+		require.NoError(t, AddTracerConfigSchema(c))
 
-		conf := Config{
+		conf := TracerConfig{
 			ServiceName: "Clinia X",
-			Provider:    "otlp",
-			Providers: ProvidersConfig{
+			TracerName:  "X",
+			Provider:    "otel",
+			Providers: TracerProvidersConfig{
 				OTLP: OTLPConfig{
 					ServerURL: "http://localhost:5778/sampling",
 					Sampling: OTLPSampling{
@@ -46,7 +47,7 @@ func TestConfigSchema(t *testing.T) {
 		rawConfig, err := sjson.Set("{}", "otelx", &conf)
 		require.NoError(t, err)
 
-		require.NoError(t, c.AddResource("config", bytes.NewBufferString(fmt.Sprintf(rootSchema, ConfigSchemaID))))
+		require.NoError(t, c.AddResource("config", bytes.NewBufferString(fmt.Sprintf(rootSchema, TracerConfigSchemaID))))
 
 		schema, err := c.Compile(context.Background(), "config")
 		require.NoError(t, err)

--- a/otelx/jaeger.go
+++ b/otelx/jaeger.go
@@ -20,7 +20,7 @@ import (
 // Optionally, Config.Providers.Jaeger.LocalAgentAddress can be set.
 // NOTE: If Config.Providers.Jaeger.Sampling.ServerURL is not specfied,
 // AlwaysSample is used.
-func SetupJaegerTracer(tracerName string, c *Config) (trace.Tracer, propagation.TextMapPropagator, error) {
+func SetupJaegerTracer(tracerName string, c *TracerConfig) (trace.Tracer, propagation.TextMapPropagator, error) {
 	host, port, err := net.SplitHostPort(c.Providers.Jaeger.LocalAgentAddress)
 	if err != nil {
 		return nil, nil, err

--- a/otelx/otel.go
+++ b/otelx/otel.go
@@ -4,126 +4,50 @@
 package otelx
 
 import (
-	"context"
-
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/clinia/x/logrusx"
-	"github.com/clinia/x/stringsx"
 )
 
-type Tracer struct {
-	tracer     trace.Tracer
-	propagator propagation.TextMapPropagator
+type Otel struct {
+	t *Tracer
+	// m *Meter
+}
+
+type OtelOptions struct {
+	TracerConfig *TracerConfig
+	// MeterConfig  *MeterConfig
 }
 
 // Creates a new tracer. If name is empty, a default tracer name is used
 // instead. See: https://godocs.io/go.opentelemetry.io/otel/sdk/trace#TracerProvider.Tracer
-func New(name string, l *logrusx.Logger, c *Config) (*Tracer, error) {
+func New(l *logrusx.Logger, opts OtelOptions) (*Otel, error) {
 	t := &Tracer{}
-
-	if err := t.setup(name, l, c); err != nil {
-		return nil, err
-	}
-
-	return t, nil
-}
-
-// Creates a new no-op tracer.
-func NewNoop(_ *logrusx.Logger, c *Config) *Tracer {
-	tp := trace.NewNoopTracerProvider()
-	t := &Tracer{tracer: tp.Tracer("")}
-	return t
-}
-
-// setup constructs the tracer based on the given configuration.
-func (t *Tracer) setup(name string, l *logrusx.Logger, c *Config) error {
-	switch f := stringsx.SwitchExact(c.Provider); {
-	case f.AddCase("jaeger"):
-		tracer, prop, err := SetupJaegerTracer(name, c)
-		if err != nil {
-			return err
+	if opts.TracerConfig != nil {
+		if err := t.setup(l, opts.TracerConfig); err != nil {
+			return nil, err
 		}
-
-		t.tracer = tracer
-		t.propagator = prop
-		l.Infof("Jaeger tracer configured! Sending spans to %s", c.Providers.Jaeger.LocalAgentAddress)
-	case f.AddCase("otel"):
-		tracer, prop, err := SetupOTLPTracer(name, c)
-		if err != nil {
-			return err
-		}
-
-		t.tracer = tracer
-		t.propagator = prop
-		l.Infof("OTLP tracer configured! Sending spans to %s", c.Providers.OTLP.ServerURL)
-	case f.AddCase("stdout"):
-		tracer, prop, err := SetupStdoutTracer(name, c)
-		if err != nil {
-			return err
-		}
-
-		t.tracer = tracer
-		t.propagator = prop
-		l.Infof("Stdout tracer configured! Sending spans to stdout")
-	case f.AddCase(""):
-		l.Infof("Missing provider in config - skipping tracing setup")
+	} else {
 		t.tracer = trace.NewNoopTracerProvider().Tracer("NoopTracer")
 		t.propagator = propagation.NewCompositeTextMapPropagator()
-	default:
-		return f.ToUnknownCaseErr()
 	}
-	return nil
-}
 
-// IsLoaded returns true if the tracer has been loaded.
-func (t *Tracer) IsLoaded() bool {
-	if t == nil || t.tracer == nil {
-		return false
+	o := &Otel{
+		t: t,
 	}
-	return true
+	return o, nil
 }
 
-// Tracer returns the underlying OpenTelemetry tracer.
-func (t *Tracer) Tracer() trace.Tracer {
-	return t.tracer
-}
+// Creates a new no-op tracer and meter.
+func NewNoop() *Otel {
+	t := &Tracer{tracer: trace.NewNoopTracerProvider().Tracer("NoopTracer")}
 
-// WithOTLP returns a new tracer with the underlying OpenTelemetry Tracer
-// replaced.
-func (t *Tracer) WithOTLP(other trace.Tracer) *Tracer {
-	return &Tracer{tracer: other}
-}
+	// mp := sdk.NewMeterProvider()
+	// m := &Meter{meter: mp.Meter("")}
 
-// Provider returns a TracerProvider which in turn yieds this tracer unmodified.
-func (t *Tracer) Provider() trace.TracerProvider {
-	return tracerProvider{t.Tracer()}
-}
-
-type tracerProvider struct {
-	t trace.Tracer
-}
-
-var _ trace.TracerProvider = tracerProvider{}
-
-// Tracer implements trace.TracerProvider.
-func (tp tracerProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
-	return tp.t
-}
-
-// TextMapPropagator returns the underlying OpenTelemetry textMapPropagator.
-func (t *Tracer) TextMapPropagator() propagation.TextMapPropagator {
-	return t.propagator
-}
-
-// Inject set tracecontext from the Context into the carrier.
-func (t *Tracer) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
-	t.propagator.Inject(ctx, carrier)
-}
-
-// Extract reads tracecontext from the carrier into a returned Context.
-// If the extracted tracecontext is invalid, the passed ctx will be returned directly instead.
-func (t *Tracer) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
-	return t.propagator.Extract(ctx, carrier)
+	return &Otel{
+		t: t,
+		// Metric: m,
+	}
 }

--- a/otelx/otel_test.go
+++ b/otelx/otel_test.go
@@ -1,90 +1,21 @@
-// Copyright © 2023 Ory Corp
-// SPDX-License-Identifier: Apache-2.0
-
 package otelx
 
 import (
-	"compress/gzip"
-	"compress/zlib"
-	"context"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
-	"google.golang.org/protobuf/proto"
-
-	tracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 
 	"github.com/clinia/x/logrusx"
+	"github.com/stretchr/testify/assert"
 )
 
-func decodeResponseBody(t *testing.T, r *http.Request) []byte {
-	var reader io.ReadCloser
-	switch r.Header.Get("Content-Encoding") {
-	case "gzip":
-		var err error
-		reader, err = gzip.NewReader(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-	case "deflate":
-		var err error
-		reader, err = zlib.NewReader(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-	default:
-		reader = r.Body
-	}
-	respBody, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.NoError(t, reader.Close())
-	return respBody
-}
-
-func TestOTLPTracer(t *testing.T) {
-	done := make(chan struct{})
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body := decodeResponseBody(t, r)
-
-		var res tracepb.ExportTraceServiceRequest
-		err := proto.Unmarshal(body, &res)
-		require.NoError(t, err, "must be able to unmarshal traces")
-
-		resourceSpans := res.GetResourceSpans()
-		spans := resourceSpans[0].GetScopeSpans()[0].GetSpans()
-		assert.Equal(t, len(spans), 1)
-
-		assert.NotEmpty(t, spans[0].GetSpanId())
-		assert.NotEmpty(t, spans[0].GetTraceId())
-		assert.Equal(t, "testSpan", spans[0].GetName())
-		assert.Equal(t, "testAttribute", spans[0].Attributes[0].Key)
-
-		close(done)
-	}))
-	defer ts.Close()
-
-	tsu, err := url.Parse(ts.URL)
-	require.NoError(t, err)
-
-	opts := &OtelOptions{}
-	opts.TracerConfig = &TracerConfig{
+func TestNewWithTracerConfig(t *testing.T) {
+	tracerConfig := &TracerConfig{
 		ServiceName: "Clinia X",
-		TracerName:  "X",
+		Name:        "X",
 		Provider:    "otel",
 		Providers: TracerProvidersConfig{
 			OTLP: OTLPConfig{
-				Protocol:  "http",
-				ServerURL: tsu.Host,
-				Insecure:  true,
+				Protocol: "grpc",
+				Insecure: true,
 				Sampling: OTLPSampling{
 					SamplingRatio: 1,
 				},
@@ -92,17 +23,10 @@ func TestOTLPTracer(t *testing.T) {
 		},
 	}
 
-	ot, err := New(logrusx.New("clinia/x", "1"), *opts)
+	otel, err := New(logrusx.New("clinia/x", "1"), WithTracer(tracerConfig))
+
 	assert.NoError(t, err)
-
-	trc := ot.t.Tracer()
-	_, span := trc.Start(context.Background(), "testSpan")
-	span.SetAttributes(attribute.Bool("testAttribute", true))
-	span.End()
-
-	select {
-	case <-done:
-	case <-time.After(15 * time.Second):
-		t.Fatalf("Test server did not receive spans")
-	}
+	assert.NotNil(t, otel.Tracer())
+	assert.NotNil(t, otel.Tracer().Provider())
+	assert.NotNil(t, otel.Tracer().TextMapPropagator())
 }

--- a/otelx/otlp.go
+++ b/otelx/otlp.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func SetupOTLPTracer(tracerName string, c *Config) (trace.Tracer, propagation.TextMapPropagator, error) {
+func SetupOTLPTracer(tracerName string, c *TracerConfig) (trace.Tracer, propagation.TextMapPropagator, error) {
 	exp, err := getExporter(c)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -50,7 +50,7 @@ func SetupOTLPTracer(tracerName string, c *Config) (trace.Tracer, propagation.Te
 	return tp.Tracer(tracerName), prop, nil
 }
 
-func getExporter(c *Config) (*otlptrace.Exporter, error) {
+func getExporter(c *TracerConfig) (*otlptrace.Exporter, error) {
 	ctx := context.Background()
 
 	if c.Providers.OTLP.Protocol == "http" {

--- a/otelx/stdout.go
+++ b/otelx/stdout.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func SetupStdoutTracer(tracerName string, c *Config) (trace.Tracer, propagation.TextMapPropagator, error) {
+func SetupStdoutTracer(tracerName string, c *TracerConfig) (trace.Tracer, propagation.TextMapPropagator, error) {
 	opts := []stdouttrace.Option{}
 
 	if c.Providers.Stdout.Pretty {

--- a/otelx/tracer.go
+++ b/otelx/tracer.go
@@ -1,0 +1,90 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package otelx
+
+import (
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/clinia/x/logrusx"
+	"github.com/clinia/x/stringsx"
+)
+
+type Tracer struct {
+	tracer     trace.Tracer
+	propagator propagation.TextMapPropagator
+}
+
+// setup constructs the tracer based on the given configuration.
+func (t *Tracer) setup(l *logrusx.Logger, c *TracerConfig) error {
+	switch f := stringsx.SwitchExact(c.Provider); {
+	case f.AddCase("jaeger"):
+		tracer, prop, err := SetupJaegerTracer(c.TracerName, c)
+		if err != nil {
+			return err
+		}
+
+		t.tracer = tracer
+		t.propagator = prop
+		l.Infof("Jaeger tracer configured! Sending spans to %s", c.Providers.Jaeger.LocalAgentAddress)
+	case f.AddCase("otel"):
+		tracer, prop, err := SetupOTLPTracer(c.TracerName, c)
+		if err != nil {
+			return err
+		}
+
+		t.tracer = tracer
+		t.propagator = prop
+		l.Infof("OTLP tracer configured! Sending spans to %s", c.Providers.OTLP.ServerURL)
+	case f.AddCase("stdout"):
+		tracer, prop, err := SetupStdoutTracer(c.TracerName, c)
+		if err != nil {
+			return err
+		}
+
+		t.tracer = tracer
+		t.propagator = prop
+		l.Infof("Stdout tracer configured! Sending spans to stdout")
+	case f.AddCase(""):
+		l.Infof("No tracer configured - skipping tracing setup")
+		t.tracer = trace.NewNoopTracerProvider().Tracer(c.TracerName)
+	default:
+		return f.ToUnknownCaseErr()
+	}
+	return nil
+}
+
+// IsLoaded returns true if the tracer has been loaded.
+func (t *Tracer) IsLoaded() bool {
+	if t == nil || t.tracer == nil {
+		return false
+	}
+	return true
+}
+
+// Tracer returns the underlying OpenTelemetry tracer.
+func (t *Tracer) Tracer() trace.Tracer {
+	return t.tracer
+}
+
+// Provider returns a TracerProvider which in turn yieds this tracer unmodified.
+func (t *Tracer) Provider() trace.TracerProvider {
+	return tracerProvider{t.Tracer()}
+}
+
+type tracerProvider struct {
+	t trace.Tracer
+}
+
+var _ trace.TracerProvider = tracerProvider{}
+
+// Tracer implements trace.TracerProvider.
+func (tp tracerProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+	return tp.t
+}
+
+// TextMapPropagator returns the underlying OpenTelemetry textMapPropagator.
+func (t *Tracer) TextMapPropagator() propagation.TextMapPropagator {
+	return t.propagator
+}

--- a/otelx/tracer.schema.json
+++ b/otelx/tracer.schema.json
@@ -1,20 +1,25 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "clinia://tracing-config",
+    "$id": "clinia://tracer-config",
     "type": "object",
     "additionalProperties": false,
-    "description": "Configure distributed tracing using OpenTelemetry",
+    "description": "Configure distributed tracer using OpenTelemetry",
     "properties": {
       "provider": {
         "type": "string",
-        "description": "Set this to the tracing backend you wish to use. Supports OTEL.",
-        "enum": ["otlp", "stdout", "jaeger"],
-        "examples": ["otlp"]
+        "description": "Set this to the tracer backend you wish to use. Supports OTEL.",
+        "enum": ["otel", "stdout", "jaeger"],
+        "examples": ["otel"]
       },
       "service_name": {
         "type": "string",
         "description": "Specifies the service name to use on the tracer.",
-        "examples": ["Clinia Data Fabric", "Clinia Health Grade Search", "Clinia Care Paths"]
+        "examples": ["Clinia Atlas", "Clinia Health Grade Search", "Clinia Care Paths"]
+      },
+      "tracer_name": {
+        "type": "string",
+        "description": "Specifies the tracer name.",
+        "examples": ["Clinia Atlas"]
       },
       "providers": {
         "type": "object",
@@ -23,7 +28,7 @@
           "jaeger": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Configures the jaeger tracing backend.",
+            "description": "Configures the jaeger tracer backend.",
             "properties": {
               "local_agent_address": {
                 "type": "string",
@@ -64,7 +69,7 @@
           "otlp": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Configures the OTLP tracing backend.",
+            "description": "Configures the OTLP tracer backend.",
             "properties": {
               "protocol": {
                 "type": "string",
@@ -114,7 +119,7 @@
           "stdout": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Configures the Stdout tracing backend.",
+            "description": "Configures the Stdout tracer backend.",
             "properties": {
               "pretty": {
                 "type": "boolean",

--- a/otelx/tracer_config.go
+++ b/otelx/tracer_config.go
@@ -44,7 +44,7 @@ type TracerProvidersConfig struct {
 
 type TracerConfig struct {
 	ServiceName        string                `json:"service_name"`
-	TracerName         string                `json:"tracer_name"`
+	Name               string                `json:"name"`
 	Provider           string                `json:"provider"`
 	Providers          TracerProvidersConfig `json:"tracer_providers"`
 	ResourceAttributes []attribute.KeyValue  `json:"resource_attributes"`

--- a/otelx/tracer_config.go
+++ b/otelx/tracer_config.go
@@ -36,28 +36,29 @@ type StdoutConfig struct {
 	Pretty bool `json:"pretty"`
 }
 
-type ProvidersConfig struct {
+type TracerProvidersConfig struct {
 	Jaeger JaegerConfig `json:"jaeger"`
 	OTLP   OTLPConfig   `json:"otlp"`
 	Stdout StdoutConfig `json:"stdout"`
 }
 
-type Config struct {
-	ServiceName        string               `json:"service_name"`
-	Provider           string               `json:"provider"`
-	Providers          ProvidersConfig      `json:"providers"`
-	ResourceAttributes []attribute.KeyValue `json:"resource_attributes"`
+type TracerConfig struct {
+	ServiceName        string                `json:"service_name"`
+	TracerName         string                `json:"tracer_name"`
+	Provider           string                `json:"provider"`
+	Providers          TracerProvidersConfig `json:"tracer_providers"`
+	ResourceAttributes []attribute.KeyValue  `json:"resource_attributes"`
 }
 
-//go:embed config.schema.json
-var ConfigSchema string
+//go:embed tracer.schema.json
+var TracerConfigSchema string
 
-const ConfigSchemaID = "clinia://tracing-config"
+const TracerConfigSchemaID = "clinia://tracer-config"
 
-// AddConfigSchema adds the tracing schema to the compiler.
+// AddTracerConfigSchema adds the tracer schema to the compiler.
 // The interface is specified instead of `jsonschema.Compiler` to allow the use of any jsonschema library fork or version.
-func AddConfigSchema(c interface {
+func AddTracerConfigSchema(c interface {
 	AddResource(url string, r io.Reader) error
 }) error {
-	return c.AddResource(ConfigSchemaID, bytes.NewBufferString(ConfigSchema))
+	return c.AddResource(TracerConfigSchemaID, bytes.NewBufferString(TracerConfigSchema))
 }

--- a/otelx/tracer_test.go
+++ b/otelx/tracer_test.go
@@ -1,0 +1,178 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package otelx
+
+import (
+	"compress/gzip"
+	"compress/zlib"
+	"context"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	tracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+
+	"github.com/clinia/x/logrusx"
+)
+
+func decodeResponseBody(t *testing.T, r *http.Request) []byte {
+	var reader io.ReadCloser
+	switch r.Header.Get("Content-Encoding") {
+	case "gzip":
+		var err error
+		reader, err = gzip.NewReader(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	case "deflate":
+		var err error
+		reader, err = zlib.NewReader(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+	default:
+		reader = r.Body
+	}
+	respBody, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	return respBody
+}
+
+func TestHTTPOTLPTracer(t *testing.T) {
+	done := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := decodeResponseBody(t, r)
+
+		var res tracepb.ExportTraceServiceRequest
+		err := proto.Unmarshal(body, &res)
+		require.NoError(t, err, "must be able to unmarshal traces")
+
+		resourceSpans := res.GetResourceSpans()
+		spans := resourceSpans[0].GetScopeSpans()[0].GetSpans()
+		assert.Equal(t, len(spans), 1)
+
+		assert.NotEmpty(t, spans[0].GetSpanId())
+		assert.NotEmpty(t, spans[0].GetTraceId())
+		assert.Equal(t, "testSpan", spans[0].GetName())
+		assert.Equal(t, "testAttribute", spans[0].Attributes[0].Key)
+
+		close(done)
+	}))
+	defer ts.Close()
+
+	tsu, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	tracerConfig := &TracerConfig{
+		ServiceName: "Clinia X",
+		Name:        "X",
+		Provider:    "otel",
+		Providers: TracerProvidersConfig{
+			OTLP: OTLPConfig{
+				Protocol:  "http",
+				ServerURL: tsu.Host,
+				Insecure:  true,
+				Sampling: OTLPSampling{
+					SamplingRatio: 1,
+				},
+			},
+		},
+	}
+
+	tr := &Tracer{}
+	err = tr.setup(logrusx.New("clinia/x", "1"), tracerConfig)
+	assert.NoError(t, err)
+
+	_, span := tr.Tracer().Start(context.Background(), "testSpan")
+	span.SetAttributes(attribute.Bool("testAttribute", true))
+	span.End()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Test server did not receive spans")
+	}
+}
+
+type TraceServiceServer struct {
+	tracepb.TraceServiceServer
+	t    *testing.T
+	done chan struct{}
+}
+
+func (s *TraceServiceServer) Export(ctx context.Context, req *tracepb.ExportTraceServiceRequest) (*tracepb.ExportTraceServiceResponse, error) {
+	resourceSpans := req.GetResourceSpans()
+	spans := resourceSpans[0].GetScopeSpans()[0].GetSpans()
+	assert.Equal(s.t, len(spans), 1)
+
+	assert.NotEmpty(s.t, spans[0].GetSpanId())
+	assert.NotEmpty(s.t, spans[0].GetTraceId())
+	assert.Equal(s.t, "testSpan", spans[0].GetName())
+	assert.Equal(s.t, "testAttribute", spans[0].Attributes[0].Key)
+
+	close(s.done)
+
+	return nil, nil
+}
+
+func TestGRPCOTLPTracer(t *testing.T) {
+	done := make(chan struct{})
+
+	grpcServer := grpc.NewServer()
+	service := &TraceServiceServer{t: t, done: done}
+
+	tracepb.RegisterTraceServiceServer(grpcServer, service)
+	lis, err := net.Listen("tcp", "localhost:0") // Listen on a random available port
+	assert.NoError(t, err)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			log.Fatalf("Failed to start gRPC server: %v", err)
+		}
+	}()
+	defer grpcServer.Stop()
+
+	tracerConfig := &TracerConfig{
+		ServiceName: "Clinia X",
+		Name:        "X",
+		Provider:    "otel",
+		Providers: TracerProvidersConfig{
+			OTLP: OTLPConfig{
+				Protocol:  "grpc",
+				ServerURL: lis.Addr().String(),
+				Insecure:  true,
+				Sampling: OTLPSampling{
+					SamplingRatio: 1,
+				},
+			},
+		},
+	}
+
+	tr := &Tracer{}
+	err = tr.setup(logrusx.New("clinia/x", "1"), tracerConfig)
+	assert.NoError(t, err)
+
+	_, span := tr.Tracer().Start(context.Background(), "testSpan")
+	span.SetAttributes(attribute.Bool("testAttribute", true))
+	span.End()
+
+	select {
+	case <-service.done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Test server did not receive spans")
+	}
+}


### PR DESCRIPTION
This PR implement a OTEL struct type which contains the tracer, it will allow in a next PR to add meter in the Otel struct.
- Move Tracer implementation in own folder + add test for the GRPC (only http was implemented which is not the one we use in atlas)
- Rename tracer specific config to allow implement of meter.