### PR TITLE
chore: Support scoped migrations

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# Enable/disable creation of status checks
+enabled: true
+titleOnly: true

--- a/arangox/migrator.go
+++ b/arangox/migrator.go
@@ -162,8 +162,8 @@ func (m *Migrator) Version(ctx context.Context) (uint64, string, error) {
 	return rec.Version, rec.Description, nil
 }
 
-// SetVersion forcibly changes database version to provided.
-func (m *Migrator) SetVersion(ctx context.Context, version uint64, description string) error {
+// setVersion forcibly changes database version to provided.
+func (m *Migrator) setVersion(ctx context.Context, version uint64, description string) error {
 	rec := versionRecord{
 		Version:     version,
 		Package:     m.pkg,
@@ -206,7 +206,7 @@ func (m *Migrator) Up(ctx context.Context, n int) error {
 		if err := migration.Up(ctx, m.db); err != nil {
 			return err
 		}
-		if err := m.SetVersion(ctx, migration.Version, migration.Description); err != nil {
+		if err := m.setVersion(ctx, migration.Version, migration.Description); err != nil {
 			return err
 		}
 	}
@@ -242,7 +242,7 @@ func (m *Migrator) Down(ctx context.Context, n int) error {
 		} else {
 			prevMigration = m.migrations[i-1]
 		}
-		if err := m.SetVersion(ctx, prevMigration.Version, prevMigration.Description); err != nil {
+		if err := m.setVersion(ctx, prevMigration.Version, prevMigration.Description); err != nil {
 			return err
 		}
 	}

--- a/elasticx/index_test.go
+++ b/elasticx/index_test.go
@@ -228,7 +228,7 @@ func TestIndexReadDocument(t *testing.T) {
 	f := newTestFixture(t)
 	ctx := f.ctx
 
-	engine, err := f.client.CreateEngine(ctx, "test-index-delete-document")
+	engine, err := f.client.CreateEngine(ctx, "test-index-read-document")
 	assert.NoError(t, err)
 
 	index, err := engine.CreateIndex(ctx, "index-1", &CreateIndexOptions{

--- a/elasticx/migrate/migration_test.go
+++ b/elasticx/migrate/migration_test.go
@@ -21,22 +21,28 @@ func TestMigration(t *testing.T) {
 		assert.NoError(t, err)
 		engines = append(engines, engine.Name())
 
-		migrator := NewMigrator(engine, Migration{
-			Version:     uint64(1),
-			Description: "Test initial migration",
-			Up: func(ctx context.Context, engine elasticx.Engine) error {
-				_, err := engine.CreateIndex(ctx, "test-index", nil)
-				assert.NoError(t, err)
+		migrator := NewMigrator(NewMigratorOptions{
+			Engine:  engine,
+			Package: "",
+			Migrations: []Migration{
+				{
+					Version:     uint64(1),
+					Description: "Test initial migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						_, err := engine.CreateIndex(ctx, "test-index", nil)
+						assert.NoError(t, err)
 
-				return nil
-			},
-			Down: func(ctx context.Context, engine elasticx.Engine) error {
-				index, err := engine.Index(ctx, "test-index")
-				if err != nil {
-					return err
-				}
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						index, err := engine.Index(ctx, "test-index")
+						if err != nil {
+							return err
+						}
 
-				return index.Remove(ctx)
+						return index.Remove(ctx)
+					},
+				},
 			},
 		})
 
@@ -47,13 +53,146 @@ func TestMigration(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 
-		res, err := f.es.Get("clinia-engines~test-migrations-a~migrations", "1").Do(ctx)
+		res, err := f.es.Get("clinia-engines~test-migrations-a~migrations", ":1").Do(ctx)
 		assert.NoError(t, err)
 		assert.True(t, res.Found)
 		assertx.EqualAsJSONExcept(t, versionRecord{
 			Version:     uint64(1),
 			Description: "Test initial migration",
 		}, res.Source_, []string{"timestamp"})
+
+		verInfo, err := migrator.Version(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, versionRecord{
+			Version:     uint64(1),
+			Description: "Test initial migration",
+		}, verInfo)
+	})
+
+	t.Run("should be able to add migration with same version in multiple packages only", func(t *testing.T) {
+		engine, err := client.CreateEngine(ctx, "test-migrations-b")
+		assert.NoError(t, err)
+		engines = append(engines, engine.Name())
+
+		migratorA := NewMigrator(NewMigratorOptions{
+			Engine:  engine,
+			Package: "package-1",
+			Migrations: []Migration{
+				{
+					Version:     uint64(1),
+					Description: "Test initial migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						_, err := engine.CreateIndex(ctx, "test-index", nil)
+						assert.NoError(t, err)
+
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						index, err := engine.Index(ctx, "test-index")
+						if err != nil {
+							return err
+						}
+
+						return index.Remove(ctx)
+					},
+				},
+			},
+		})
+
+		migratorB := NewMigrator(NewMigratorOptions{
+			Engine:  engine,
+			Package: "package-2",
+			Migrations: []Migration{
+				{
+					Version:     uint64(1),
+					Description: "Test initial migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						_, err := engine.CreateIndex(ctx, "test-index-2", nil)
+						assert.NoError(t, err)
+
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						index, err := engine.Index(ctx, "test-index-2")
+						if err != nil {
+							return err
+						}
+
+						return index.Remove(ctx)
+					},
+				},
+			},
+		})
+
+		err = migratorA.Up(ctx, AllAvailable)
+		assert.NoError(t, err)
+
+		err = migratorB.Up(ctx, AllAvailable)
+		assert.NoError(t, err)
+
+		exists, err := f.es.Indices.Exists("clinia-engines~test-migrations-b~migrations").Do(ctx)
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+		res, err := f.es.Get("clinia-engines~test-migrations-b~migrations", "package-1:1").Do(ctx)
+		assert.NoError(t, err)
+		assert.True(t, res.Found)
+		assertx.EqualAsJSONExcept(t, versionRecord{
+			Version:     uint64(1),
+			Package:     "package-1",
+			Description: "Test initial migration",
+		}, res.Source_, []string{"timestamp"})
+
+		res2, err := f.es.Get("clinia-engines~test-migrations-b~migrations", "package-2:1").Do(ctx)
+		assert.NoError(t, err)
+		assert.True(t, res2.Found)
+		assertx.EqualAsJSONExcept(t, versionRecord{
+			Version:     uint64(1),
+			Package:     "package-2",
+			Description: "Test initial migration",
+		}, res2.Source_, []string{"timestamp"})
+	})
+
+	t.Run("should panic when passing a migrations with conflicting versions", func(t *testing.T) {
+		engine, err := client.CreateEngine(ctx, "test-migrations-c")
+		assert.NoError(t, err)
+		engines = append(engines, engine.Name())
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("The code did not panic")
+			} else {
+				assert.Equal(t, "duplicated migration version 1", r)
+			}
+		}()
+
+		// Should panic
+		NewMigrator(NewMigratorOptions{
+			Engine:  engine,
+			Package: "package-1",
+			Migrations: []Migration{
+				{
+					Version:     uint64(1),
+					Description: "Test initial migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+				},
+				{
+					Version:     uint64(1),
+					Description: "Duplicated migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+				},
+			},
+		})
 	})
 
 	t.Cleanup(func() {

--- a/elasticx/migrate/migration_test.go
+++ b/elasticx/migrate/migration_test.go
@@ -63,7 +63,7 @@ func TestMigration(t *testing.T) {
 
 		verInfo, err := migrator.Version(ctx)
 		assert.NoError(t, err)
-		assert.Equal(t, versionRecord{
+		assert.Equal(t, migrationVersionInfo{
 			Version:     uint64(1),
 			Description: "Test initial migration",
 		}, verInfo)


### PR DESCRIPTION
Add support for scoped migrations so that we can separate dynamic migrations by package across the same engine