### PR TITLE
fix: arango migrations down not removing version record document & scoped pubsub

### DIFF
--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Config struct {
+	Scope     string          `json:"scope"`
 	Provider  string          `json:"provider"`
 	Providers ProvidersConfig `json:"providers"`
 }

--- a/pubsubx/config.schema.json
+++ b/pubsubx/config.schema.json
@@ -5,6 +5,13 @@
     "additionalProperties": false,
     "description": "Configure Pub sub using the following options",
     "properties": {
+        "scope": {
+            "type": "string",
+            "description": "Set this to the scope you wish to use for pub sub. Defaults to the application id.",
+            "examples": [
+                "my-app"
+            ]
+        },
         "provider": {
             "type": "string",
             "description": "Set this to the pub sub backend you wish to use. Supports inmemory and kafka. Defaults to inmemory.",

--- a/pubsubx/kafka.go
+++ b/pubsubx/kafka.go
@@ -11,6 +11,14 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 )
 
+type kafkaPublisher struct {
+	scope      string
+	publisher  *kafka.Publisher
+	propagator propagation.TextMapPropagator
+}
+
+var _ Publisher = (*kafkaPublisher)(nil)
+
 // TODO: add publisher configs
 func SetupKafkaPublisher(l *logrusx.Logger, c *Config, opts *pubSubOptions) (Publisher, error) {
 	conf := kafka.PublisherConfig{
@@ -30,13 +38,11 @@ func SetupKafkaPublisher(l *logrusx.Logger, c *Config, opts *pubSubOptions) (Pub
 		return nil, err
 	}
 
-	kafkaPub := &kafkaPublisher{publisher: *publisher, propagator: opts.propagator}
-	return kafkaPub, nil
-}
-
-type kafkaPublisher struct {
-	publisher  kafka.Publisher
-	propagator propagation.TextMapPropagator
+	return &kafkaPublisher{
+		scope:      c.Scope,
+		publisher:  publisher,
+		propagator: opts.propagator,
+	}, nil
 }
 
 func (p *kafkaPublisher) Publish(ctx context.Context, topic string, messages ...*message.Message) error {
@@ -45,13 +51,20 @@ func (p *kafkaPublisher) Publish(ctx context.Context, topic string, messages ...
 			p.propagator.Inject(ctx, propagation.MapCarrier(msg.Metadata))
 		}
 	}
-	return p.publisher.Publish(topic, messages...)
+	return p.publisher.Publish(topicName(p.scope, topic), messages...)
 
 }
 
 func (p *kafkaPublisher) Close() error {
 	return p.publisher.Close()
 }
+
+type kafkaSubscriber struct {
+	scope      string
+	subscriber *kafka.Subscriber
+}
+
+var _ Subscriber = (*kafkaSubscriber)(nil)
 
 // TODO: add subscriber configs
 func SetupKafkaSubscriber(l *logrusx.Logger, c *Config, opts *pubSubOptions, group string) (Subscriber, error) {
@@ -81,5 +94,18 @@ func SetupKafkaSubscriber(l *logrusx.Logger, c *Config, opts *pubSubOptions, gro
 		return nil, err
 	}
 
-	return subscriber, nil
+	return &kafkaSubscriber{
+		scope:      c.Scope,
+		subscriber: subscriber,
+	}, nil
+}
+
+// Close implements Subscriber.
+func (s *kafkaSubscriber) Close() error {
+	return s.subscriber.Close()
+}
+
+// Subscribe implements Subscriber.
+func (s *kafkaSubscriber) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
+	return s.subscriber.Subscribe(ctx, topicName(s.scope, topic))
 }

--- a/pubsubx/pubsub.go
+++ b/pubsubx/pubsub.go
@@ -1,6 +1,7 @@
 package pubsubx
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/clinia/x/logrusx"
@@ -114,4 +115,12 @@ func (ps *pubSub) Close() error {
 	}
 
 	return nil
+}
+
+func topicName(scope, topic string) string {
+	if scope != "" {
+		return fmt.Sprintf("%s.%s", scope, topic)
+	}
+
+	return topic
 }


### PR DESCRIPTION
I've finally moved the scoped config inside our pubsub package which makes it cleaner and removes some bugs related the pointers and channels.

I've also fixed our arango migrations package so that the down migrations properly manage the versioned documents.