### PR TITLE
feat: [ENG-673] Update logrux WithContext

### DIFF
--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -44,7 +44,7 @@ func (l *Logger) NewEntry() *Logger {
 
 func (l *Logger) WithContext(ctx context.Context) *Logger {
 	ll := *l
-	ll.Entry = l.Logger.WithContext(ctx)
+	ll.Entry = l.Entry.WithContext(ctx)
 	return &ll
 }
 


### PR DESCRIPTION
This PR implements changes in logrusx, use l.Entry.WithContext(ctx) instead of l.Logger.WithContext(ctx) which overwrited the Entry info