### PR TITLE
feat: logrusx add option to write_to_file

### DIFF
--- a/logrusx/logrus.go
+++ b/logrusx/logrus.go
@@ -213,4 +213,12 @@ func (l *Logger) UseConfig(c configurator) {
 	o := newOptions(append(l.opts, WithConfigurator(c)))
 	setLevel(l.Entry.Logger, o)
 	setFormatter(l.Entry.Logger, o)
+
+	if c.String("log.write_to_file") != "" {
+		logFile, err := os.OpenFile(c.String("log.write_to_file"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			l.WithError(err).Errorf("unable to open file '%s'", c.String("log.write_to_file"))
+		}
+		l.Entry.Logger.Out = io.MultiWriter(os.Stderr, logFile)
+	}
 }

--- a/logrusx/logrus.go
+++ b/logrusx/logrus.go
@@ -218,7 +218,8 @@ func (l *Logger) UseConfig(c configurator) {
 		logFile, err := os.OpenFile(c.String("log.write_to_file"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 		if err != nil {
 			l.WithError(err).Errorf("unable to open file '%s'", c.String("log.write_to_file"))
+		} else {
+			l.Entry.Logger.Out = io.MultiWriter(os.Stderr, logFile)
 		}
-		l.Entry.Logger.Out = io.MultiWriter(os.Stderr, logFile)
 	}
 }


### PR DESCRIPTION
This PR implements a multi-writer in logger with a write_to_file option. It allows in atlas (if set) to have the logs available in Loki and link to traces. The main purpose is for local development and debugging.