### PR TITLE
feat: [ENG-740] Change migrator usage

### DIFF
--- a/arangox/migration.go
+++ b/arangox/migration.go
@@ -27,9 +27,11 @@ type Migration struct {
 	Down        MigrationFunc
 }
 
-func migrationSort(migrations []Migration) {
-	sort.Slice(migrations, func(i, j int) bool {
-		return migrations[i].Version < migrations[j].Version
+type Migrations []Migration
+
+func (m Migrations) Sort() {
+	sort.Slice(m, func(i, j int) bool {
+		return m[i].Version < m[j].Version
 	})
 }
 

--- a/arangox/migrator.go
+++ b/arangox/migrator.go
@@ -105,7 +105,6 @@ func (m *Migrator) Version(ctx context.Context) (current uint64, latest uint64, 
 		return 0, latest, "", err
 	}
 
-	var cursor arangoDriver.Cursor
 	cursor, err := m.db.Query(ctx, `
 		FOR m IN @@collection 
 			FILTER m.package == @pkg 

--- a/arangox/migrator.go
+++ b/arangox/migrator.go
@@ -138,6 +138,7 @@ func (m *Migrator) Version(ctx context.Context) (current uint64, latest uint64, 
 // If targetVersion<=0 all "up" migrations will be executed (if not executed yet)
 // If targetVersion>0 only migrations where version<=targetVersion will be performed (if not executed yet)
 func (m *Migrator) Up(ctx context.Context, targetVersion int) error {
+	m.migrations.Sort()
 	currentVersion, latest, _, err := m.Version(ctx)
 	if err != nil {
 		return err
@@ -149,8 +150,6 @@ func (m *Migrator) Up(ctx context.Context, targetVersion int) error {
 	} else {
 		target = uint64(mathx.Clamp(targetVersion, 0, int(latest)))
 	}
-
-	m.migrations.Sort()
 
 	col, err := m.db.Collection(ctx, m.migrationsCollection)
 	if err != nil {

--- a/arangox/migrator.go
+++ b/arangox/migrator.go
@@ -205,6 +205,7 @@ func (m *Migrator) Down(ctx context.Context, targetVersion int) error {
 		}
 
 		if migration.Version <= uint64(target) {
+			// We down-ed enough
 			break
 		}
 

--- a/elasticx/migrate/migration.go
+++ b/elasticx/migrate/migration.go
@@ -27,9 +27,11 @@ type Migration struct {
 	Down        MigrationFunc
 }
 
-func migrationSort(migrations []Migration) {
-	sort.Slice(migrations, func(i, j int) bool {
-		return migrations[i].Version < migrations[j].Version
+type Migrations []Migration
+
+func (m Migrations) Sort() {
+	sort.Slice(m, func(i, j int) bool {
+		return m[i].Version < m[j].Version
 	})
 }
 

--- a/elasticx/migrate/migration_test.go
+++ b/elasticx/migrate/migration_test.go
@@ -2,11 +2,17 @@ package migrate
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/clinia/x/assertx"
 	"github.com/clinia/x/elasticx"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/sortorder"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMigration(t *testing.T) {
@@ -193,6 +199,137 @@ func TestMigration(t *testing.T) {
 				},
 			},
 		})
+	})
+
+	t.Run("should be able to migrate up in batches", func(t *testing.T) {
+		engine, err := client.CreateEngine(ctx, "test-migrations-d")
+		assert.NoError(t, err)
+		engines = append(engines, engine.Name())
+
+		m := NewMigrator(NewMigratorOptions{
+			Engine:  engine,
+			Package: "package-1",
+			Migrations: []Migration{
+				{
+					Version:     uint64(1),
+					Description: "Test initial migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						_, err := engine.CreateIndex(ctx, "test-index", nil)
+						assert.NoError(t, err)
+
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						index, err := engine.Index(ctx, "test-index")
+						if err != nil {
+							return err
+						}
+
+						return index.Remove(ctx)
+					},
+				},
+				{
+					Version:     uint64(2),
+					Description: "Test second migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+				},
+				{
+					Version:     uint64(3),
+					Description: "Test third migration",
+					Up: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+					Down: func(ctx context.Context, engine elasticx.Engine) error {
+						return nil
+					},
+				},
+			},
+		})
+
+		getVersions := func() []versionRecord {
+			searchResponse, err := m.engine.Query(ctx, &search.Request{
+				Query: &types.Query{
+					Term: map[string]types.TermQuery{
+						"package": {
+							Value: m.pkg,
+						},
+					},
+				},
+				Sort: types.Sort{
+					types.SortOptions{
+						SortOptions: map[string]types.FieldSort{
+							"version": {
+								Order: &sortorder.Desc,
+							},
+						},
+					},
+				},
+			}, m.migrationsIndex)
+
+			require.NoError(t, err)
+
+			out := make([]versionRecord, len(searchResponse.Hits.Hits))
+			for i, hit := range searchResponse.Hits.Hits {
+				var rec versionRecord
+
+				if err := json.Unmarshal(hit.Source_, &rec); err != nil {
+					t.Fatal(err)
+				}
+
+				out[i] = rec
+			}
+
+			return out
+		}
+
+		exists, err := f.es.Indices.Exists("clinia-engines~test-migrations-d~migrations").Do(ctx)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+
+		err = m.Up(ctx, 1)
+		assert.NoError(t, err)
+
+		exists, err = f.es.Indices.Exists("clinia-engines~test-migrations-d~migrations").Do(ctx)
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+		versions := getVersions()
+		assert.Len(t, versions, 1)
+		assertx.ElementsMatch(t, versions, []versionRecord{
+			{
+				Version:     uint64(1),
+				Package:     "package-1",
+				Description: "Test initial migration",
+			},
+		}, cmpopts.IgnoreFields(versionRecord{}, "Timestamp"))
+
+		err = m.Up(ctx, 3)
+		assert.NoError(t, err)
+
+		versions = getVersions()
+		assert.Len(t, versions, 3)
+		assertx.ElementsMatch(t, versions, []versionRecord{
+			{
+				Version:     uint64(1),
+				Package:     "package-1",
+				Description: "Test initial migration",
+			},
+			{
+				Version:     uint64(2),
+				Package:     "package-1",
+				Description: "Test second migration",
+			},
+			{
+				Version:     uint64(3),
+				Package:     "package-1",
+				Description: "Test third migration",
+			},
+		}, cmpopts.IgnoreFields(versionRecord{}, "Timestamp"))
 	})
 
 	t.Cleanup(func() {

--- a/elasticx/migrate/migrator.go
+++ b/elasticx/migrate/migrator.go
@@ -47,14 +47,14 @@ const AllAvailable = -1
 type Migrator struct {
 	engine          elasticx.Engine
 	pkg             string
-	migrations      []Migration
+	migrations      Migrations
 	migrationsIndex string
 }
 
 type NewMigratorOptions struct {
 	Engine     elasticx.Engine
 	Package    string
-	Migrations []Migration
+	Migrations Migrations
 }
 
 func NewMigrator(opts NewMigratorOptions) *Migrator {
@@ -242,7 +242,7 @@ func (m *Migrator) Up(ctx context.Context, n int) error {
 	if n <= 0 || n > len(m.migrations) {
 		n = len(m.migrations)
 	}
-	migrationSort(m.migrations)
+	m.migrations.Sort()
 
 	for i, p := 0, 0; i < len(m.migrations) && p < n; i++ {
 		migration := m.migrations[i]
@@ -271,7 +271,7 @@ func (m *Migrator) Down(ctx context.Context, n int) error {
 	if n <= 0 || n > len(m.migrations) {
 		n = len(m.migrations)
 	}
-	migrationSort(m.migrations)
+	m.migrations.Sort()
 
 	for i, p := len(m.migrations)-1, 0; i >= 0 && p < n; i-- {
 		migration := m.migrations[i]

--- a/mathx/clamp.go
+++ b/mathx/clamp.go
@@ -1,0 +1,18 @@
+package mathx
+
+type Number interface {
+	int | int8 | int16 | int32 | int64 |
+		float32 | float64 |
+		uint | uint8 | uint16 | uint32 | uint64
+}
+
+// Clamp returns the value of x clamped to the range [min, max].
+func Clamp[N Number](x, min, max N) N {
+	if x < min {
+		return min
+	}
+	if x > max {
+		return max
+	}
+	return x
+}

--- a/mathx/clamp_test.go
+++ b/mathx/clamp_test.go
@@ -1,0 +1,116 @@
+package mathx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClamp(t *testing.T) {
+	t.Parallel()
+
+	// Test floats
+	{
+		for _, test := range []struct {
+			v, low, high, expected float32
+		}{
+			{
+				v:        0.5,
+				low:      0,
+				high:     1,
+				expected: 0.5,
+			},
+			{
+				v:        -0.5,
+				low:      0,
+				high:     1,
+				expected: 0,
+			},
+			{
+				v:        1.5,
+				low:      0,
+				high:     1,
+				expected: 1,
+			},
+
+			{
+				v:        1.5,
+				low:      1,
+				high:     2,
+				expected: 1.5,
+			},
+			{
+				v:        0.5,
+				low:      1,
+				high:     2,
+				expected: 1,
+			},
+			{
+				v:        2.5,
+				low:      1,
+				high:     2,
+				expected: 2,
+			},
+			{
+				v:        0.999999,
+				low:      1,
+				high:     2,
+				expected: 1,
+			},
+			{
+				v:        2.000001,
+				low:      1,
+				high:     2,
+				expected: 2,
+			},
+			{
+				v:        1.000001,
+				low:      1,
+				high:     2,
+				expected: 1.000001,
+			},
+		} {
+			assert.Equal(t, test.expected, Clamp(test.v, test.low, test.high))
+		}
+	}
+
+	// Test ints
+	{
+		for _, test := range []struct {
+			v, low, high, expected int
+		}{
+			{
+				v:        5,
+				low:      0,
+				high:     10,
+				expected: 5,
+			},
+			{
+				v:        -5,
+				low:      0,
+				high:     10,
+				expected: 0,
+			},
+			{
+				v:        15,
+				low:      0,
+				high:     10,
+				expected: 10,
+			},
+			{
+				v:        10,
+				low:      0,
+				high:     10,
+				expected: 10,
+			},
+			{
+				v:        0,
+				low:      0,
+				high:     10,
+				expected: 0,
+			},
+		} {
+			assert.Equal(t, test.expected, Clamp(test.v, test.low, test.high))
+		}
+	}
+}


### PR DESCRIPTION
This PR modifies the pattern used for running migrations; Instead of passing `n` migrations to execute (Up or Down), the caller should now provide a `targetVersion` to migrate up or down to.

- [x] Adapt Elasticx migrator with this pattern

Turns out the elasticx migrator was not functioning at all for down migrations as we were calling a `setVersion` instead of removing the down-ed version.