### PR TITLE
fix: Release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           node-version: "14"
       - name: Define next tag
-        run:
-          echo -e "Current version = v$(npx semver -- $(git describe --tags --abbrev=0))\nNext version = v$(npx semver -- $(git describe --tags --abbrev=0) --increment=patch)"
+        run: |
+          echo "Current version = v$(npx semver -- $(git describe --tags --abbrev=0))"
+          echo "Next version = v$(npx semver -- $(git describe --tags --abbrev=0) --increment=patch)"
       - name: Create git tag
         run: |
           git tag "v$(npx semver -- $(git describe --tags --abbrev=0) --increment=patch)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
           node-version: "14"
       - name: Define next tag
         run:
-          npx semver -- $(git describe --tags `git rev-list --tags --max-count=1`)
+          echo -e "Current version = v$(npx semver -- $(git describe --tags --abbrev=0))\nNext version = v$(npx semver -- $(git describe --tags --abbrev=0) --increment=patch)"
       - name: Create git tag
         run: |
-          git tag "v$(npx semver -- $(git describe --tags `git rev-list --tags --max-count=1`) --increment=patch)"
+          git tag "v$(npx semver -- $(git describe --tags --abbrev=0) --increment=patch)"
       - name: Push git tag
         run: git push --tags


### PR DESCRIPTION
The release CI was taking the latest tag even if it was on a separate branch.