### PR TITLE
feat: [ENG-1233] Add details property in Clinia error

### DIFF
--- a/errorx/error.go
+++ b/errorx/error.go
@@ -12,7 +12,10 @@ type CliniaError struct {
 	Type    ErrorType `json:"type"`
 	Message string    `json:"message"`
 
-	OriginalError error // Not returned to clients
+	// Not returned to clients
+	OriginalError error
+	// List of errors that caused the error if applicable
+	Details []CliniaError
 }
 
 var _ error = (*CliniaError)(nil)
@@ -21,6 +24,15 @@ type CliniaRetryableError = CliniaError
 
 func (e CliniaError) Error() string {
 	return fmt.Sprintf("[%s] %s", e.Type.String(), e.Message)
+}
+
+// WithDetails allows to attach multiple errors to the error
+func (c *CliniaError) WithDetails(details ...CliniaError) *CliniaError {
+	if c.Details == nil {
+		c.Details = make([]CliniaError, 0, len(details))
+	}
+	c.Details = append(c.Details, details...)
+	return c
 }
 
 func NewCliniaErrorFromMessage(msg string) (*CliniaError, error) {

--- a/errorx/error.go
+++ b/errorx/error.go
@@ -27,12 +27,12 @@ func (e CliniaError) Error() string {
 }
 
 // WithDetails allows to attach multiple errors to the error
-func (c *CliniaError) WithDetails(details ...CliniaError) *CliniaError {
+func (c *CliniaError) WithDetails(details ...CliniaError) CliniaError {
 	if c.Details == nil {
 		c.Details = make([]CliniaError, 0, len(details))
 	}
 	c.Details = append(c.Details, details...)
-	return c
+	return *c
 }
 
 func NewCliniaErrorFromMessage(msg string) (*CliniaError, error) {

--- a/errorx/error_test.go
+++ b/errorx/error_test.go
@@ -33,4 +33,36 @@ func TestError(t *testing.T) {
 		err := NotFoundErrorf("test")
 		assert.True(t, IsNotFoundError(err))
 	})
+
+	t.Run("should append details to existing error", func(t *testing.T) {
+		cerr := FailedPreconditionErrorf("test")
+		cerr = cerr.WithDetails(NotFoundErrorf("testnotfound"))
+		assert.Equal(t, CliniaError{
+			Type:    ErrorTypeFailedPrecondition,
+			Message: "test",
+			Details: []CliniaError{
+				{
+					Type:    ErrorTypeNotFound,
+					Message: "testnotfound",
+				},
+			},
+		}, cerr)
+
+		// Append more details
+		cerr = cerr.WithDetails(InvalidArgumentErrorf("testinvalid"))
+		assert.Equal(t, CliniaError{
+			Type:    ErrorTypeFailedPrecondition,
+			Message: "test",
+			Details: []CliniaError{
+				{
+					Type:    ErrorTypeNotFound,
+					Message: "testnotfound",
+				},
+				{
+					Type:    ErrorTypeInvalidArgument,
+					Message: "testinvalid",
+				},
+			},
+		}, cerr)
+	})
 }


### PR DESCRIPTION
This PR adds in Clinia Error struct a details property which would contain all errors that caused the root error