### PR TITLE
feat: [ENG-1454] Health checks

### DIFF
--- a/pubsubx/inmemory/pubsub.go
+++ b/pubsubx/inmemory/pubsub.go
@@ -127,3 +127,8 @@ func (m *memorySubscriber) Subscribe(ctx context.Context, topicHandlers pubsubx.
 func (m *memoryPubSub) AdminClient() (pubsubx.PubSubAdminClient, error) {
 	return NewNoopAdminClient(), nil
 }
+
+// Health implements pubsubx.Subscriber.
+func (m *memorySubscriber) Health() error {
+	return nil
+}

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -284,3 +284,14 @@ func (c *consumer) Subscribe(ctx context.Context, topicHandlers pubsubx.Handlers
 
 	return nil
 }
+
+// Health implements pubsubx.Subscriber.
+func (c *consumer) Health() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.cancel == nil {
+		return errorx.InternalErrorf("not subscribed to topics")
+	}
+
+	return nil
+}

--- a/pubsubx/mocks/Subscriber.go
+++ b/pubsubx/mocks/Subscriber.go
@@ -32,6 +32,24 @@ func (_m *Subscriber) Close() error {
 	return r0
 }
 
+// Health provides a mock function with given fields:
+func (_m *Subscriber) Health() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Health")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Subscribe provides a mock function with given fields: ctx, topicHandlers
 func (_m *Subscriber) Subscribe(ctx context.Context, topicHandlers pubsubx.Handlers) error {
 	ret := _m.Called(ctx, topicHandlers)

--- a/pubsubx/subscriber.go
+++ b/pubsubx/subscriber.go
@@ -11,6 +11,10 @@ type (
 	// It takes a context.Context and a slice of *messagex.Message as input parameters.
 	// The function should return a slice of errors, representing per-message failures,
 	// and an error, representing the processing failure in general.
+	//
+	// For the singular error, the caller may return a pubsubx.AbortSubscribeError() to abort the subscription right away.
+	// For any other errors happening, the handler will be retried up to a certain number of times. After that, the subscription will be aborted.
+	// As such, it is the caller's responsibility to return an error that is related to the batch processing itself and not to a specific message.
 	Handler  func(ctx context.Context, msgs []*messagex.Message) ([]error, error)
 	Handlers map[messagex.Topic]Handler
 )

--- a/pubsubx/subscriber.go
+++ b/pubsubx/subscriber.go
@@ -20,6 +20,9 @@ type Subscriber interface {
 	// It takes a context and a map of topic handlers as input.
 	// - If there are topics missing handlers, it will return an error immediately.
 	Subscribe(ctx context.Context, topicHandlers Handlers) error
+	// Health returns the health status of the subscriber.
+	// It should return an error if the subscriber is unhealthy, nil otherwise (healthy).
+	Health() error
 	// Close closes the subscriber.
 	Close() error
 }

--- a/pubsubx/subscriber_error.go
+++ b/pubsubx/subscriber_error.go
@@ -11,10 +11,8 @@ func (e *SubscriberError) Error() string {
 	return e.Message
 }
 
-var (
-	// This error should be returned when the handler wishes to abort the subscription.
-	abortSubscribeError = &SubscriberError{Message: "abort subscription", Retryable: false}
-)
+// This error should be returned when the handler wishes to abort the subscription.
+var abortSubscribeError = &SubscriberError{Message: "abort subscription", Retryable: false}
 
 func AbortSubscribeError() *SubscriberError {
 	return abortSubscribeError

--- a/pubsubx/subscriber_error.go
+++ b/pubsubx/subscriber_error.go
@@ -1,0 +1,21 @@
+package pubsubx
+
+type SubscriberError struct {
+	Message   string
+	Retryable bool
+}
+
+var _ error = (*SubscriberError)(nil)
+
+func (e *SubscriberError) Error() string {
+	return e.Message
+}
+
+var (
+	// This error should be returned when the handler wishes to abort the subscription.
+	abortSubscribeError = &SubscriberError{Message: "abort subscription", Retryable: false}
+)
+
+func AbortSubscribeError() *SubscriberError {
+	return abortSubscribeError
+}


### PR DESCRIPTION
This PR adds some health checks for the subscribers in `pubsubx`. It also adds a short exponential backoff to retry handlers' failures that are retryable.