### PR TITLE
feat: query delete documents

### DIFF
--- a/elasticx/delete_query_response.go
+++ b/elasticx/delete_query_response.go
@@ -1,0 +1,9 @@
+package elasticx
+
+// string or int
+type TaskId any
+
+type DeleteQueryResponse struct {
+	TaskId      *TaskId
+	DeleteCount int64
+}

--- a/elasticx/index.go
+++ b/elasticx/index.go
@@ -3,6 +3,7 @@ package elasticx
 import (
 	"context"
 
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/refresh"
 )
 
@@ -46,11 +47,11 @@ type IndexDocuments interface {
 	// If no document exists with given key, a NotFoundError is returned.
 	DeleteDocument(ctx context.Context, key string, opts ...DocumentOption) error
 
-	// DeleteQueryDocuments deletes all documents satisfying the query.
+	// DeleteDocumentsByQuery deletes all documents satisfying the query.
 	// No error is returned when the documents are deleted
 	// If the query fails, an error is returned.
 	// The number of deleted document and the async taskId is returned.
-	DeleteQueryDocuments(ctx context.Context, jsonQuery string, opts ...DocumentOption) (*DeleteQueryResponse, error)
+	DeleteDocumentsByQuery(ctx context.Context, query *types.Query, opts ...DocumentOption) (*DeleteQueryResponse, error)
 }
 
 type IndexInfo struct {

--- a/elasticx/index.go
+++ b/elasticx/index.go
@@ -58,8 +58,8 @@ type IndexInfo struct {
 }
 
 type documentOptions struct {
-	refresh           refresh.Refresh `json:"refresh"`
-	waitForCompletion bool            `json:"waitForCompletion"`
+	refresh           refresh.Refresh
+	waitForCompletion bool
 }
 
 type DocumentOption func(*documentOptions)

--- a/elasticx/index.go
+++ b/elasticx/index.go
@@ -45,6 +45,12 @@ type IndexDocuments interface {
 	// No error is returned when the document is successfully deleted.
 	// If no document exists with given key, a NotFoundError is returned.
 	DeleteDocument(ctx context.Context, key string, opts ...DocumentOption) error
+
+	// DeleteQueryDocuments deletes all documents satisfying the query.
+	// No error is returned when the documents are deleted
+	// If the query fails, an error is returned.
+	// The number of deleted document and the async taskId is returned.
+	DeleteQueryDocuments(ctx context.Context, jsonQuery string, opts ...DocumentOption) (*DeleteQueryResponse, error)
 }
 
 type IndexInfo struct {
@@ -52,18 +58,26 @@ type IndexInfo struct {
 }
 
 type documentOptions struct {
-	refresh refresh.Refresh
+	refresh           refresh.Refresh `json:"refresh"`
+	waitForCompletion bool            `json:"waitForCompletion"`
 }
 
 type DocumentOption func(*documentOptions)
 
 var DefaultDocumentOptions = &documentOptions{
-	refresh: refresh.False,
+	refresh:           refresh.False,
+	waitForCompletion: false,
 }
 
 // WithRefresh sets the refresh option of the document operation.
 func WithRefresh(refresh refresh.Refresh) DocumentOption {
 	return func(opts *documentOptions) {
 		opts.refresh = refresh
+	}
+}
+
+func WithWaitForCompletion(waitForCompletion bool) DocumentOption {
+	return func(opts *documentOptions) {
+		opts.waitForCompletion = waitForCompletion
 	}
 }

--- a/elasticx/index_impl.go
+++ b/elasticx/index_impl.go
@@ -3,11 +3,15 @@ package elasticx
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/clinia/x/errorx"
 	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/result"
+	"github.com/samber/lo"
 	"github.com/segmentio/ksuid"
 )
 
@@ -170,5 +174,56 @@ func (i *index) indexName() IndexName {
 }
 
 func (i *index) DeleteQueryDocuments(ctx context.Context, jsonQuery string, opts ...DocumentOption) (*DeleteQueryResponse, error) {
-	return nil, nil
+	options := DefaultDocumentOptions
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	var query types.Query
+	err := json.Unmarshal([]byte(jsonQuery), &query)
+	if err != nil {
+		return nil, err
+	}
+
+	// This block is to simulate the behaviour of the `.Refresh` function on the other elastic search lib calls,
+	// for some reason the DeleteByQuery takes a boolean that is converted to a string, as the other functions use
+	// the direct string
+	refresh, refreshErr := strconv.ParseBool(options.refresh.String())
+	if refreshErr != nil {
+		refresh = false
+	}
+
+	res, err := i.es.DeleteByQuery(i.indexName().String()).
+		WaitForCompletion(options.waitForCompletion).
+		Refresh(refresh).
+		Query(&query).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// As soon as one of the query match fails the whole query execution fails, this is to join all the failures
+	// into a single error
+	if len(res.Failures) > 0 {
+		return nil, errors.Join(lo.Map(
+			res.Failures,
+			func(item types.BulkIndexByScrollFailure, _ int) error {
+				return errors.New(item.Type)
+			})...)
+	}
+
+	var deleteCount int64 = 0
+	if res.Deleted != nil {
+		deleteCount = *res.Deleted
+	}
+
+	var taskId *TaskId
+	if res.Task != nil {
+		taskId = (*TaskId)(&res.Task)
+	}
+
+	return &DeleteQueryResponse{
+		DeleteCount: deleteCount,
+		TaskId:      taskId,
+	}, nil
 }

--- a/elasticx/index_impl.go
+++ b/elasticx/index_impl.go
@@ -168,3 +168,7 @@ func (i *index) indexName() IndexName {
 	escapedName := pathEscape(i.name)
 	return NewIndexName(enginesIndexName, i.engine.name, escapedName)
 }
+
+func (i *index) DeleteQueryDocuments(ctx context.Context, jsonQuery string, opts ...DocumentOption) (*DeleteQueryResponse, error) {
+	return nil, nil
+}

--- a/elasticx/index_test.go
+++ b/elasticx/index_test.go
@@ -317,15 +317,14 @@ func TestIndexQueryDeleteDocuments(t *testing.T) {
 			"foo": "bar",
 		}, WithRefresh(refresh.True))
 		assert.NoError(t, err)
+		query := &types.Query{
+			Term: map[string]types.TermQuery{
+				"foo": {Value: "bar"},
+			},
+		}
 
 		// Act
-		result, err := index.DeleteQueryDocuments(ctx, `{
-		    "query": {
-		      "term": {
-		        "foo": { "value": "bar" }
-		        }
-		      }
-		    }`,
+		result, err := index.DeleteDocumentsByQuery(ctx, query,
 			WithWaitForCompletion(true),
 			WithRefresh(refresh.True),
 		)
@@ -347,6 +346,11 @@ func TestIndexQueryDeleteDocuments(t *testing.T) {
 		assert.False(t, exists)
 	})
 
+	t.Run("should fail on empty query", func(t *testing.T) {
+		_, err := index.DeleteDocumentsByQuery(ctx, nil)
+		assert.Error(t, err)
+	})
+
 	t.Run("should delete all foo key documents async", func(t *testing.T) {
 		// Prepare
 		meta1, err := index.CreateDocument(ctx, map[string]interface{}{
@@ -363,15 +367,14 @@ func TestIndexQueryDeleteDocuments(t *testing.T) {
 			"foo": "bar",
 		}, WithRefresh(refresh.True))
 		assert.NoError(t, err)
+		query := &types.Query{
+			Term: map[string]types.TermQuery{
+				"foo": {Value: "bar"},
+			},
+		}
 
 		// Act
-		result, err := index.DeleteQueryDocuments(ctx, `{
-		    "query": {
-		      "term": {
-		        "foo": { "value": "bar" }
-		        }
-		      }
-		    }`,
+		result, err := index.DeleteDocumentsByQuery(ctx, query,
 			WithWaitForCompletion(false),
 		)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR adds the capability to pass in a JSON string query to a new API to allow the document deletion matching the query `DeleteQueryDocuments`. The JSON input is the elastic search QSL but under the go-lang struct format. Since this task can includes multiple match, it allows the configuration of ASYNC or SYNC execution and the retrieval of the TaskId to check on the progress of the ASYNC task.