### PR TITLE
fix: Consumer retries

### DIFF
--- a/internal/tracex/stack.go
+++ b/internal/tracex/stack.go
@@ -1,0 +1,25 @@
+package internaltracex
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func GetStackTrace(skipLevels int) string {
+	// Skip the first two callers (CallerStackTrace and ExampleFunction)
+	pc := make([]uintptr, 10)
+	n := runtime.Callers(skipLevels, pc)
+	frames := runtime.CallersFrames(pc[:n])
+
+	var stackBuf string
+	for {
+		frame, more := frames.Next()
+		stackBuf += fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
+		if !more || len(stackBuf) > 1024 {
+			break
+		}
+
+	}
+
+	return stackBuf
+}

--- a/internal/tracex/stack.go
+++ b/internal/tracex/stack.go
@@ -5,8 +5,10 @@ import (
 	"runtime"
 )
 
+// GetStackTrace returns the stack trace of the caller.
+// We can specify skipLevels to skip the number of stack frames.
+// i.e. GetStackTrace(2) will skip the first 2 calls (including GetStackTrace itself), so this will return the stack trace of the caller of the function that calls GetStackTrace.
 func GetStackTrace(skipLevels int) string {
-	// Skip the first two callers (CallerStackTrace and ExampleFunction)
 	pc := make([]uintptr, 10)
 	n := runtime.Callers(skipLevels, pc)
 	frames := runtime.CallersFrames(pc[:n])

--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -11,9 +11,11 @@ import (
 	"net/url"
 	"strings"
 
+	internaltracex "github.com/clinia/x/internal/tracex"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -191,6 +193,11 @@ func (l *Logger) WithField(key string, value interface{}) *Logger {
 	ll := *l
 	ll.Entry = l.Entry.WithField(key, value)
 	return &ll
+}
+
+func (l *Logger) WithStackTrace() *Logger {
+	stackTrace := internaltracex.GetStackTrace(2)
+	return l.WithFields(NewLogFields(semconv.ExceptionStacktrace(stackTrace)))
 }
 
 func (l *Logger) maybeRedact(value interface{}) interface{} {

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -3,6 +3,7 @@ package kgox
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"time"
 
@@ -182,7 +183,10 @@ func (c *consumer) start(ctx context.Context) {
 			wrappedHandler := func(ctx context.Context, msgs []*messagex.Message) (outErrs []error, outErr error) {
 				defer func() {
 					if r := recover(); r != nil {
-						l.Errorf("panic while handling messages: %v", r)
+						stackBuf := make([]byte, 1024)
+						stackSize := runtime.Stack(stackBuf, false)
+						stackTrace := string(stackBuf[:stackSize])
+						l.Errorf("panic while handling messages: %v\nStack trace: %s", r, stackTrace)
 						outErr = errorx.InternalErrorf("panic while handling messages")
 					}
 				}()

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/clinia/x/logrusx"
 	"github.com/clinia/x/pubsubx"
 	"github.com/clinia/x/pubsubx/messagex"
-	tracexx "github.com/clinia/x/tracex"
+	"github.com/clinia/x/tracex"
 	"github.com/samber/lo"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kotel"
@@ -184,8 +184,8 @@ func (c *consumer) start(ctx context.Context) {
 				defer func() {
 					if r := recover(); r != nil {
 						outErr = errorx.InternalErrorf("panic while handling messages")
-						stackTrace := tracexx.GetStackTrace()
-						l.WithFields(logrusx.NewLogFields(semconv.ExceptionStacktrace(stackTrace))).Errorln("panic while handling messages")
+						stackTrace := tracex.GetStackTrace()
+						l.WithContext(ctx).WithFields(logrusx.NewLogFields(semconv.ExceptionStacktrace(stackTrace))).Errorln("panic while handling messages")
 					}
 				}()
 				return topicHandler(ctx, msgs)

--- a/testx/buffer.go
+++ b/testx/buffer.go
@@ -1,0 +1,32 @@
+package testx
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+type ConcurrentBuffer struct {
+	b *bytes.Buffer
+	m sync.RWMutex
+	t *testing.T
+}
+
+func NewConcurrentBuffer(t *testing.T) *ConcurrentBuffer {
+	return &ConcurrentBuffer{
+		b: new(bytes.Buffer),
+		t: t,
+	}
+}
+
+func (c *ConcurrentBuffer) Write(p []byte) (n int, err error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.b.Write(p)
+}
+
+func (c *ConcurrentBuffer) String() string {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.b.String()
+}

--- a/tracex/recover.go
+++ b/tracex/recover.go
@@ -11,7 +11,10 @@ import (
 // i.e. defer tracex.RecoverWithStackTrace(l, "panic while handling messages")
 func RecoverWithStackTrace(l *logrusx.Logger, msg string) {
 	// We don't want the recoverer itself to panic - that would be a shame.
-	defer recover()
+	defer func() {
+		// We ignore it here, as we only want to recover from panics that happen in the recover without doing anything with them.
+		recover()
+	}()
 
 	if r := recover(); r != nil {
 		if l == nil {

--- a/tracex/recover.go
+++ b/tracex/recover.go
@@ -8,11 +8,13 @@ import (
 
 // RecoverWithStackTrace recovers from a panic and logs the message with a stack trace.
 // It should only be used as a defer statement at the beginning of a function.
-// i.e. defer tracexx.RecoverWithStackTrace(l, "panic while handling messages")
+// i.e. defer tracex.RecoverWithStackTrace(l, "panic while handling messages")
 func RecoverWithStackTrace(l *logrusx.Logger, msg string) {
+	// We don't want the recoverer itself to panic - that would be a shame.
+	defer recover()
+
 	if r := recover(); r != nil {
 		if l == nil {
-			// We don't want the recoverer itself to panic
 			return
 		}
 		// We want to omit the getStackTrace but preserve RecoverWithStackTrace

--- a/tracex/recover.go
+++ b/tracex/recover.go
@@ -1,4 +1,4 @@
-package tracexx
+package tracex
 
 import (
 	internaltracex "github.com/clinia/x/internal/tracex"

--- a/tracex/recover.go
+++ b/tracex/recover.go
@@ -1,0 +1,37 @@
+package tracexx
+
+import (
+	internaltracex "github.com/clinia/x/internal/tracex"
+	"github.com/clinia/x/logrusx"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// RecoverWithStackTrace recovers from a panic and logs the message with a stack trace.
+// It should only be used as a defer statement at the beginning of a function.
+// i.e. defer tracexx.RecoverWithStackTrace(l, "panic while handling messages")
+func RecoverWithStackTrace(l *logrusx.Logger, msg string) {
+	if r := recover(); r != nil {
+		if l == nil {
+			// We don't want the recoverer itself to panic
+			return
+		}
+		// We want to omit the getStackTrace but preserve RecoverWithStackTrace
+		stackTrace := internaltracex.GetStackTrace(2)
+		l = l.WithFields(logrusx.NewLogFields(semconv.ExceptionStacktrace(stackTrace)))
+		switch v := r.(type) {
+		case string:
+			l = l.WithField(string(semconv.ExceptionMessageKey), v)
+		case error:
+			l = l.WithField(string(semconv.ExceptionMessageKey), v.Error())
+		default:
+			l = l.WithField(string(semconv.ExceptionMessageKey), "unknown panic")
+		}
+
+		l.Errorln(msg)
+	}
+}
+
+// GetStackTrace returns the stack trace of the caller.
+func GetStackTrace() string {
+	return internaltracex.GetStackTrace(3)
+}

--- a/tracex/recover_test.go
+++ b/tracex/recover_test.go
@@ -1,4 +1,4 @@
-package tracexx
+package tracex
 
 import (
 	"errors"

--- a/tracex/recover_test.go
+++ b/tracex/recover_test.go
@@ -1,0 +1,98 @@
+package tracexx
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/clinia/x/logrusx"
+	"github.com/clinia/x/testx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverWithStackTrace(t *testing.T) {
+	t.Run("should recover from panic and log stack trace", func(t *testing.T) {
+		l := logrusx.New("test", "")
+		buf := testx.NewConcurrentBuffer(t)
+		l.Entry.Logger.SetOutput(buf)
+		assertCount := 0
+		t.Cleanup(func() {
+			require.GreaterOrEqual(t, assertCount, 3)
+		})
+		defer func() {
+			assert.Contains(t, buf.String(), "panic at the disco")
+			assertCount++
+			assert.Contains(t, buf.String(), "test panic")
+			assertCount++
+			assert.Contains(t, buf.String(), "tracex/recover.go")
+			assertCount++
+		}()
+
+		defer RecoverWithStackTrace(l, "panic at the disco")
+
+		panic("test panic")
+	})
+
+	t.Run("should recover from panic and log stack trace with error panic", func(t *testing.T) {
+		l := logrusx.New("test", "")
+		buf := testx.NewConcurrentBuffer(t)
+		l.Entry.Logger.SetOutput(buf)
+		assertCount := 0
+		t.Cleanup(func() {
+			require.GreaterOrEqual(t, assertCount, 1)
+		})
+		defer func() {
+			assert.Contains(t, buf.String(), "test panic")
+			assertCount++
+		}()
+
+		defer RecoverWithStackTrace(l, "")
+
+		panic(errors.New("test panic"))
+	})
+
+	t.Run("should recover from panic and log stack trace with random types or nil", func(t *testing.T) {
+		l := logrusx.New("test", "")
+		buf := testx.NewConcurrentBuffer(t)
+		l.Entry.Logger.SetOutput(buf)
+		assertCount := 0
+		t.Cleanup(func() {
+			require.GreaterOrEqual(t, assertCount, 3)
+		})
+
+		testPanic := func(v interface{}, expectedStr string) {
+			defer func() {
+				assert.Contains(t, buf.String(), expectedStr)
+				assertCount++
+			}()
+
+			defer RecoverWithStackTrace(l, "")
+
+			panic(v)
+		}
+
+		testPanic([]int{}, "unknown panic")
+		testPanic(123, "unknown panic")
+		testPanic(struct{}{}, "unknown panic")
+	})
+
+	t.Run("should not log if logger is nil", func(t *testing.T) {
+		defer RecoverWithStackTrace(nil, "panic while handling messages")
+
+		panic("test panic")
+
+		// No assertion needed, just ensure no panic occurs
+	})
+}
+
+func TestGetStackTrace(t *testing.T) {
+	t.Run("should return stack trace", func(t *testing.T) {
+		stackTrace := GetStackTrace()
+		assert.Contains(t, stackTrace, "tracex/recover_test.go")
+	})
+
+	t.Run("should return empty stack trace if no panic", func(t *testing.T) {
+		stackTrace := GetStackTrace()
+		assert.NotEmpty(t, stackTrace)
+	})
+}


### PR DESCRIPTION
This PR fixes the retry mechanism for our consumer. We had a maxElapsedTime defined, but we really want to retry up to `maxRetryCount` times instead, defining a maximum interval between retries.

This also includes a stack trace log when panics occur for easier debugging.