### PR TITLE
fix: Hide logger methods without span/trace contexts

### DIFF
--- a/configx/options.go
+++ b/configx/options.go
@@ -116,7 +116,7 @@ func LogrusWatcher(l *logrusx.Logger) func(e watcherx.Event, err error) {
 	return func(e watcherx.Event, err error) {
 		l.WithField("file", e.Source()).
 			WithField("event_type", fmt.Sprintf("%T", e)).
-			Info("A change to a configuration file was detected.")
+			Infof("A change to a configuration file was detected.")
 
 		if et := new(jsonschema.ValidationError); errors.As(err, &et) {
 			l.WithField("event", fmt.Sprintf("%#v", et)).
@@ -132,7 +132,7 @@ func LogrusWatcher(l *logrusx.Logger) func(e watcherx.Event, err error) {
 		} else {
 			l.WithField("file", e.Source()).
 				WithField("event_type", fmt.Sprintf("%T", e)).
-				Info("Configuration change processed successfully.")
+				Infof("Configuration change processed successfully.")
 		}
 	}
 }

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -161,7 +161,7 @@ func (p *Provider) createProviders(ctx context.Context) (providers []koanf.Provi
 		paths = append(paths, p...)
 	}
 
-	p.logger.WithField("files", paths).Debug("Adding config files.")
+	p.logger.WithField("files", paths).Debugf("Adding config files.")
 	for _, path := range paths {
 		fp, err := NewKoanfFile(ctx, path)
 		if err != nil {

--- a/logrusx/config_test.go
+++ b/logrusx/config_test.go
@@ -47,8 +47,8 @@ func TestConfigSchema(t *testing.T) {
 		l := New("foo", "bar", WithConfigurator(k))
 
 		assert.True(t, l.leakSensitive)
-		assert.Equal(t, logrus.TraceLevel, l.Logger.Level)
-		assert.IsType(t, &logrus.JSONFormatter{}, l.Logger.Formatter)
+		assert.Equal(t, logrus.TraceLevel, l.Entry.Logger.Level)
+		assert.IsType(t, &logrus.JSONFormatter{}, l.Entry.Logger.Formatter)
 	})
 
 	t.Run("case=warns on unknown format", func(t *testing.T) {

--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Logger struct {
-	*logrus.Entry
+	Entry                   *logrus.Entry
 	leakSensitive           bool
 	sensitiveHeadersLowered map[string]bool
 	redactionText           string
@@ -41,7 +41,7 @@ func (l *Logger) Logrus() *logrus.Logger {
 
 func (l *Logger) NewEntry() *Logger {
 	ll := *l
-	ll.Entry = logrus.NewEntry(l.Logger)
+	ll.Entry = logrus.NewEntry(l.Entry.Logger)
 	return &ll
 }
 
@@ -118,8 +118,8 @@ func (l *Logger) WithRequest(r *http.Request) *Logger {
 
 func (l *Logger) Logf(level logrus.Level, format string, args ...interface{}) {
 	// Add traces information if available in context
-	if l.Context != nil {
-		spanCtx := trace.SpanContextFromContext(l.Context)
+	if l.Entry.Context != nil {
+		spanCtx := trace.SpanContextFromContext(l.Entry.Context)
 		if spanCtx.IsValid() {
 			if spanCtx.HasTraceID() {
 				l = l.WithField("TraceID", spanCtx.TraceID().String())
@@ -167,7 +167,7 @@ func (l *Logger) Warnf(format string, args ...interface{}) {
 }
 
 func (l *Logger) Warningf(format string, args ...interface{}) {
-	l.Warnf(format, args...)
+	l.Logf(logrus.WarnLevel, format, args...)
 }
 
 func (l *Logger) Errorf(format string, args ...interface{}) {

--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -159,7 +159,7 @@ func (l *Logger) Infof(format string, args ...interface{}) {
 }
 
 func (l *Logger) Printf(format string, args ...interface{}) {
-	l.Infof(format, args...)
+	l.Logf(logrus.InfoLevel, format, args...)
 }
 
 func (l *Logger) Warnf(format string, args ...interface{}) {

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -27,7 +27,7 @@ func TestSensitiveValues(t *testing.T) {
 		req.Header.Set("cookie", sensitiveValue)
 		req.Header.Set("set-cookie", sensitiveValue)
 
-		l.WithRequest(req).Info("test")
+		l.WithRequest(req).Infof("test")
 		output := buf.String()
 		assert.Equal(t, strings.Count(output, sensitiveValue), 4, "all sensitive headers should be shown since we are leaking sensitive values")
 		assert.NotContains(t, output, redacted, "should not redact sensitive values when explicitly set to leak")
@@ -50,7 +50,7 @@ func TestSensitiveValues(t *testing.T) {
 		req.Header.Set("cookie", sensitiveValue)
 		req.Header.Set("set-cookie", sensitiveValue)
 
-		l.WithRequest(req).Info("test")
+		l.WithRequest(req).Infof("test")
 		output := buf.String()
 		assert.Equal(t, strings.Count(output, redacted), 4, "all sensitive headers should be redacted")
 		assert.NotContains(t, output, sensitiveValue, "should not show sensitive values")
@@ -58,14 +58,14 @@ func TestSensitiveValues(t *testing.T) {
 		req.Header.Set("not-yet-sensitive", sensitiveValue)
 		buf.Reset()
 
-		l.WithRequest(req).Info("test")
+		l.WithRequest(req).Infof("test")
 		output = buf.String()
 		assert.Equal(t, strings.Count(output, redacted), 4, "all so far sensitive headers should be redacted")
 		assert.Equal(t, strings.Count(output, sensitiveValue), 1, "not-yet-sensitive should not be sensitive yet")
 
 		buf.Reset()
 		l = l.WithSensitiveHeaders("not-yet-sensitive")
-		l.WithRequest(req).Info("test")
+		l.WithRequest(req).Infof("test")
 		output = buf.String()
 		assert.Equal(t, strings.Count(output, redacted), 5, "all so far sensitive headers should be redacted")
 		assert.NotContains(t, output, sensitiveValue, "should not show sensitive values")

--- a/tracex/recover.go
+++ b/tracex/recover.go
@@ -6,10 +6,10 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-// RecoverWithStackTrace recovers from a panic and logs the message with a stack trace.
+// RecoverWithStackTracef recovers from a panic and logs the message with a stack trace.
 // It should only be used as a defer statement at the beginning of a function.
-// i.e. defer tracex.RecoverWithStackTrace(l, "panic while handling messages")
-func RecoverWithStackTrace(l *logrusx.Logger, msg string) {
+// i.e. defer tracex.RecoverWithStackTracef(l, "panic while handling messages")
+func RecoverWithStackTracef(l *logrusx.Logger, msg string, args ...interface{}) {
 	// We don't want the recoverer itself to panic - that would be a shame.
 	defer func() {
 		// We ignore it here, as we only want to recover from panics that happen in the recover without doing anything with them.
@@ -32,7 +32,7 @@ func RecoverWithStackTrace(l *logrusx.Logger, msg string) {
 			l = l.WithField(string(semconv.ExceptionMessageKey), "unknown panic")
 		}
 
-		l.Errorln(msg)
+		l.Errorf(msg, args...)
 	}
 }
 

--- a/tracex/recover_test.go
+++ b/tracex/recover_test.go
@@ -29,7 +29,7 @@ func TestRecoverWithStackTrace(t *testing.T) {
 			assertCount++
 		}()
 
-		defer RecoverWithStackTrace(l, "panic at the disco")
+		defer RecoverWithStackTracef(l, "panic at the disco")
 
 		panic("test panic")
 	})
@@ -47,7 +47,7 @@ func TestRecoverWithStackTrace(t *testing.T) {
 			assertCount++
 		}()
 
-		defer RecoverWithStackTrace(l, "")
+		defer RecoverWithStackTracef(l, "")
 
 		panic(errors.New("test panic"))
 	})
@@ -67,7 +67,7 @@ func TestRecoverWithStackTrace(t *testing.T) {
 				assertCount++
 			}()
 
-			defer RecoverWithStackTrace(l, "")
+			defer RecoverWithStackTracef(l, "")
 
 			panic(v)
 		}
@@ -91,13 +91,13 @@ func TestRecoverWithStackTrace(t *testing.T) {
 			assert.Equal(t, w.panics, 1)
 		}()
 
-		defer RecoverWithStackTrace(l, "panic while handling messages")
+		defer RecoverWithStackTracef(l, "panic while handling messages")
 
 		panic("test panic")
 	})
 
 	t.Run("should not log if logger is nil", func(t *testing.T) {
-		defer RecoverWithStackTrace(nil, "panic while handling messages")
+		defer RecoverWithStackTracef(nil, "panic while handling messages")
 
 		panic("test panic")
 


### PR DESCRIPTION
Quick PR that will prevent us from calling the non-`f` logging methods (`Error, Info, Warn, etc.`). These methods do not include the SpanID and TraceID, therefore making correlation between logs and spans very difficult.