### PR TITLE
fix: [ENG-1638] producer max message bytes

### DIFF
--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -33,8 +33,8 @@ type PubSubOptions struct {
 	TracerProvider trace.TracerProvider
 	Propagator     propagation.TextMapPropagator
 	MeterProvider  metric.MeterProvider
-	MaxMessageByte *int
-	RetentionMs    *int
+	MaxMessageByte *int32
+	RetentionMs    *int32
 }
 
 type PubSubOption func(*PubSubOptions)
@@ -67,14 +67,14 @@ func WithMeterProvider(provider metric.MeterProvider) PubSubOption {
 
 // WithMaxMessageByte specifies the max message size in bytes.
 // If none is specified, the default value is 1 MB.
-func WithMaxMessageByte(max int) PubSubOption {
+func WithMaxMessageByte(max int32) PubSubOption {
 	return func(opts *PubSubOptions) {
 		opts.MaxMessageByte = pointerx.Ptr(max)
 	}
 }
 
 // WithRetentionMs specifies the retention time in milliseconds.
-func WithRetentionMs(retentionMs int) PubSubOption {
+func WithRetentionMs(retentionMs int32) PubSubOption {
 	return func(opts *PubSubOptions) {
 		opts.RetentionMs = pointerx.Ptr(retentionMs)
 	}

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 
+	"github.com/clinia/x/pointerx"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -29,10 +30,11 @@ type KafkaConfig struct {
 }
 
 type PubSubOptions struct {
-	TracerProvider                  trace.TracerProvider
-	Propagator                      propagation.TextMapPropagator
-	MeterProvider                   metric.MeterProvider
-	DefaultCreateTopicConfigEntries map[string]*string
+	TracerProvider trace.TracerProvider
+	Propagator     propagation.TextMapPropagator
+	MeterProvider  metric.MeterProvider
+	MaxMessageByte *int
+	RetentionMs    *int
 }
 
 type PubSubOption func(*PubSubOptions)
@@ -63,9 +65,18 @@ func WithMeterProvider(provider metric.MeterProvider) PubSubOption {
 	}
 }
 
-func WithDefaultCreateTopicConfigEntries(entries map[string]*string) PubSubOption {
+// WithMaxMessageByte specifies the max message size in bytes.
+// If none is specified, the default value is 1 MB.
+func WithMaxMessageByte(max int) PubSubOption {
 	return func(opts *PubSubOptions) {
-		opts.DefaultCreateTopicConfigEntries = entries
+		opts.MaxMessageByte = pointerx.Ptr(max)
+	}
+}
+
+// WithRetentionMs specifies the retention time in milliseconds.
+func WithRetentionMs(retentionMs int) PubSubOption {
+	return func(opts *PubSubOptions) {
+		opts.RetentionMs = pointerx.Ptr(retentionMs)
 	}
 }
 

--- a/pubsubx/kgox/pubsub.go
+++ b/pubsubx/kgox/pubsub.go
@@ -45,12 +45,11 @@ func NewPubSub(l *logrusx.Logger, config *pubsubx.Config, opts *pubsubx.PubSubOp
 
 	// Setup kotel
 	var kotelService *kotel.Kotel
-	var defaultCreateTopicConfigEntries map[string]*string
+	defaultCreateTopicConfigEntries := map[string]*string{}
 	if opts != nil {
 		kotelService = newKotel(opts.TracerProvider, opts.Propagator, opts.MeterProvider)
 		kopts = append(kopts, kgo.WithHooks(kotelService.Hooks()...))
 
-		defaultCreateTopicConfigEntries = map[string]*string{}
 		if opts.MaxMessageByte != nil {
 			defaultCreateTopicConfigEntries["max.message.bytes"] = pointerx.Ptr(fmt.Sprintf("%d", *opts.MaxMessageByte))
 			kopts = append(kopts, kgo.ProducerBatchMaxBytes(int32(*opts.MaxMessageByte)))

--- a/pubsubx/kgox/pubsub.go
+++ b/pubsubx/kgox/pubsub.go
@@ -2,7 +2,7 @@ package kgox
 
 import (
 	"errors"
-	"strconv"
+	"fmt"
 	"sync"
 
 	"github.com/clinia/x/pointerx"
@@ -52,11 +52,11 @@ func NewPubSub(l *logrusx.Logger, config *pubsubx.Config, opts *pubsubx.PubSubOp
 
 		defaultCreateTopicConfigEntries = map[string]*string{}
 		if opts.MaxMessageByte != nil {
-			defaultCreateTopicConfigEntries["max.message.bytes"] = pointerx.Ptr(strconv.Itoa(*opts.MaxMessageByte))
+			defaultCreateTopicConfigEntries["max.message.bytes"] = pointerx.Ptr(fmt.Sprintf("%d", *opts.MaxMessageByte))
 			kopts = append(kopts, kgo.ProducerBatchMaxBytes(int32(*opts.MaxMessageByte)))
 		}
 		if opts.RetentionMs != nil {
-			defaultCreateTopicConfigEntries["retention.ms"] = pointerx.Ptr(strconv.Itoa(*opts.RetentionMs))
+			defaultCreateTopicConfigEntries["retention.ms"] = pointerx.Ptr(fmt.Sprintf("%d", *opts.RetentionMs))
 		}
 	}
 


### PR DESCRIPTION
This PR modifies the pubsub opts so send the max-message-bytes and retention-time separately. This way we can use the max message bytes opts value for the topic and the producer