### PR TITLE
feat: [ENG-1749] add DeleteGroup and DeleteGroups admin client override for `kgox` and DeleteTopic(s)WithRetryTopics

### DIFF
--- a/pubsubx/admin_client.go
+++ b/pubsubx/admin_client.go
@@ -15,6 +15,10 @@ type PubSubAdminClient interface {
 	CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, topics []string, configs ...map[string]*string) (kadm.CreateTopicResponses, error)
 	// DeleteTopic deletes a topic.
 	DeleteTopic(ctx context.Context, topic string) (kadm.DeleteTopicResponse, error)
+	// DeleteGroup deletes a group and related resources.
+	DeleteGroup(ctx context.Context, group string) (kadm.DeleteGroupResponse, error)
+	// DeleteGroups deletes groups and related resources.
+	DeleteGroups(ctx context.Context, groups ...string) (kadm.DeleteGroupResponses, error)
 	// HealthCheck checks the health of the underlying pubsub. It returns an error if the pubsub is unhealthy or we cannot connect to it.
 	HealthCheck(ctx context.Context) error
 

--- a/pubsubx/admin_client.go
+++ b/pubsubx/admin_client.go
@@ -15,6 +15,10 @@ type PubSubAdminClient interface {
 	CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, topics []string, configs ...map[string]*string) (kadm.CreateTopicResponses, error)
 	// DeleteTopic deletes a topic.
 	DeleteTopic(ctx context.Context, topic string) (kadm.DeleteTopicResponse, error)
+	// DeleteTopicsWithRetryTopics deletes the topics with their related retry topics.
+	DeleteTopicsWithRetryTopics(ctx context.Context, topics ...string) (kadm.DeleteTopicResponses, error)
+	// DeleteTopicWithRetryTopics deletes a topic with it's related retry topics.
+	DeleteTopicWithRetryTopics(ctx context.Context, topic string) (kadm.DeleteTopicResponses, error)
 	// DeleteGroup deletes a group and related resources.
 	DeleteGroup(ctx context.Context, group string) (kadm.DeleteGroupResponse, error)
 	// DeleteGroups deletes groups and related resources.

--- a/pubsubx/admin_client.go
+++ b/pubsubx/admin_client.go
@@ -3,6 +3,7 @@ package pubsubx
 import (
 	"context"
 
+	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/twmb/franz-go/pkg/kadm"
 )
 
@@ -20,9 +21,9 @@ type PubSubAdminClient interface {
 	// DeleteTopicWithRetryTopics deletes a topic with it's related retry topics.
 	DeleteTopicWithRetryTopics(ctx context.Context, topic string) (kadm.DeleteTopicResponses, error)
 	// DeleteGroup deletes a group and related resources.
-	DeleteGroup(ctx context.Context, group string) (kadm.DeleteGroupResponse, error)
+	DeleteGroup(ctx context.Context, group messagex.ConsumerGroup) (kadm.DeleteGroupResponse, error)
 	// DeleteGroups deletes groups and related resources.
-	DeleteGroups(ctx context.Context, groups ...string) (kadm.DeleteGroupResponses, error)
+	DeleteGroups(ctx context.Context, groups ...messagex.ConsumerGroup) (kadm.DeleteGroupResponses, error)
 	// HealthCheck checks the health of the underlying pubsub. It returns an error if the pubsub is unhealthy or we cannot connect to it.
 	HealthCheck(ctx context.Context) error
 

--- a/pubsubx/config.schema.json
+++ b/pubsubx/config.schema.json
@@ -14,6 +14,7 @@
     },
     "poisonQueue": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "topicName": {
           "type": "string",

--- a/pubsubx/inmemory/noop_admin_client.go
+++ b/pubsubx/inmemory/noop_admin_client.go
@@ -82,6 +82,30 @@ func (n *NoopAdminClient) DeleteTopic(ctx context.Context, topic string) (kadm.D
 	}, nil
 }
 
+func (n *NoopAdminClient) DeleteTopicsWithRetryTopics(ctx context.Context, topics ...string) (kadm.DeleteTopicResponses, error) {
+	res := make(kadm.DeleteTopicResponses)
+	for _, t := range topics {
+		for lt := range n.topics {
+			if strings.HasPrefix(lt, t) && strings.HasSuffix(lt, messagex.TopicRetrySuffix) {
+				delete(n.topics, lt)
+				res[lt] = kadm.DeleteTopicResponse{
+					Topic: t,
+				}
+
+			}
+		}
+		delete(n.topics, t)
+		res[t] = kadm.DeleteTopicResponse{
+			Topic: t,
+		}
+	}
+	return res, nil
+}
+
+func (n *NoopAdminClient) DeleteTopicWithRetryTopics(ctx context.Context, topic string) (kadm.DeleteTopicResponses, error) {
+	return n.DeleteTopicsWithRetryTopics(ctx, topic)
+}
+
 func (n *NoopAdminClient) DeleteGroup(ctx context.Context, group string) (kadm.DeleteGroupResponse, error) {
 	for t := range n.topics {
 		if strings.HasSuffix(t, group+messagex.TopicSeparator+messagex.TopicRetrySuffix) {

--- a/pubsubx/inmemory/noop_admin_client.go
+++ b/pubsubx/inmemory/noop_admin_client.go
@@ -11,13 +11,15 @@ import (
 
 type NoopAdminClient struct {
 	topics kadm.TopicDetails
+	*pubsubx.Config
 }
 
 var _ pubsubx.PubSubAdminClient = (*NoopAdminClient)(nil)
 
-func NewNoopAdminClient() pubsubx.PubSubAdminClient {
+func NewNoopAdminClient(c *pubsubx.Config) pubsubx.PubSubAdminClient {
 	return &NoopAdminClient{
 		topics: make(kadm.TopicDetails),
+		Config: c,
 	}
 }
 
@@ -113,7 +115,7 @@ func (n *NoopAdminClient) DeleteGroup(ctx context.Context, group messagex.Consum
 		}
 	}
 	return kadm.DeleteGroupResponse{
-		Group: group.ConsumerGroup(""),
+		Group: group.ConsumerGroup(n.Scope),
 		Err:   nil,
 	}, nil
 }
@@ -122,7 +124,7 @@ func (n *NoopAdminClient) DeleteGroup(ctx context.Context, group messagex.Consum
 func (n *NoopAdminClient) DeleteGroups(ctx context.Context, groups ...messagex.ConsumerGroup) (kadm.DeleteGroupResponses, error) {
 	res := make(kadm.DeleteGroupResponses)
 	for _, g := range groups {
-		gScoped := g.ConsumerGroup("")
+		gScoped := g.ConsumerGroup(n.Scope)
 		for t := range n.topics {
 			if strings.HasSuffix(t, string(g)+messagex.TopicSeparator+messagex.TopicRetrySuffix) {
 				delete(n.topics, t)

--- a/pubsubx/inmemory/noop_admin_client.go
+++ b/pubsubx/inmemory/noop_admin_client.go
@@ -106,29 +106,30 @@ func (n *NoopAdminClient) DeleteTopicWithRetryTopics(ctx context.Context, topic 
 	return n.DeleteTopicsWithRetryTopics(ctx, topic)
 }
 
-func (n *NoopAdminClient) DeleteGroup(ctx context.Context, group string) (kadm.DeleteGroupResponse, error) {
+func (n *NoopAdminClient) DeleteGroup(ctx context.Context, group messagex.ConsumerGroup) (kadm.DeleteGroupResponse, error) {
 	for t := range n.topics {
-		if strings.HasSuffix(t, group+messagex.TopicSeparator+messagex.TopicRetrySuffix) {
+		if strings.HasSuffix(t, string(group)+messagex.TopicSeparator+messagex.TopicRetrySuffix) {
 			delete(n.topics, t)
 		}
 	}
 	return kadm.DeleteGroupResponse{
-		Group: group,
+		Group: group.ConsumerGroup(""),
 		Err:   nil,
 	}, nil
 }
 
 // DeleteGroups deletes groups and related resources.
-func (n *NoopAdminClient) DeleteGroups(ctx context.Context, groups ...string) (kadm.DeleteGroupResponses, error) {
+func (n *NoopAdminClient) DeleteGroups(ctx context.Context, groups ...messagex.ConsumerGroup) (kadm.DeleteGroupResponses, error) {
 	res := make(kadm.DeleteGroupResponses)
 	for _, g := range groups {
+		gScoped := g.ConsumerGroup("")
 		for t := range n.topics {
-			if strings.HasSuffix(t, g+messagex.TopicSeparator+messagex.TopicRetrySuffix) {
+			if strings.HasSuffix(t, string(g)+messagex.TopicSeparator+messagex.TopicRetrySuffix) {
 				delete(n.topics, t)
 			}
 		}
-		res[g] = kadm.DeleteGroupResponse{
-			Group: g,
+		res[gScoped] = kadm.DeleteGroupResponse{
+			Group: gScoped,
 			Err:   nil,
 		}
 	}

--- a/pubsubx/inmemory/pubsub.go
+++ b/pubsubx/inmemory/pubsub.go
@@ -16,6 +16,7 @@ type (
 		scope       string
 		mu          sync.RWMutex
 		subscribers []*memorySubscriber
+		*pubsubx.Config
 	}
 	memorySubscriber struct {
 		m             *memoryPubSub
@@ -35,6 +36,7 @@ func SetupInMemoryPubSub(l *logrusx.Logger, c *pubsubx.Config) (*memoryPubSub, e
 	return &memoryPubSub{
 		scope:       c.Scope,
 		subscribers: make([]*memorySubscriber, 0),
+		Config:      c,
 	}, nil
 }
 
@@ -125,7 +127,7 @@ func (m *memorySubscriber) Subscribe(ctx context.Context, topicHandlers pubsubx.
 
 // AdminClient implements PubSub.
 func (m *memoryPubSub) AdminClient() (pubsubx.PubSubAdminClient, error) {
-	return NewNoopAdminClient(), nil
+	return NewNoopAdminClient(m.Config), nil
 }
 
 // Health implements pubsubx.Subscriber.

--- a/pubsubx/kgox/admin_client_impl_test.go
+++ b/pubsubx/kgox/admin_client_impl_test.go
@@ -254,8 +254,9 @@ func TestKadminClient_DeleteGroup(t *testing.T) {
 			kgo.ConsumerGroup(cGroup.ConsumerGroup(config.Scope)),
 			kgo.ConsumeTopics(topics[0].TopicName(config.Scope), retryTopic.TopicName(config.Scope)),
 		)
+		assert.NoError(t, err)
 		time.Sleep(500 * time.Millisecond)
-		groupClient.PollFetches(nil)
+		groupClient.ForceMetadataRefresh()
 		time.Sleep(500 * time.Millisecond)
 		startTopics, err := kadmCl.ListTopics(ctx)
 		assert.Contains(t, startTopics.TopicsList().Topics(), retryTopic.TopicName(config.Scope))
@@ -324,14 +325,16 @@ func TestKadminClient_DeleteGroups(t *testing.T) {
 			kgo.ConsumerGroup(cGroup.ConsumerGroup(config.Scope)),
 			kgo.ConsumeTopics(topics[0].TopicName(config.Scope), retryTopic.TopicName(config.Scope)),
 		)
+		assert.NoError(t, err)
 		groupClient2, err := kgo.NewClient(
 			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
 			kgo.ConsumerGroup(cGroup2.ConsumerGroup(config.Scope)),
 			kgo.ConsumeTopics(topics[0].TopicName(config.Scope), retryTopic.TopicName(config.Scope)),
 		)
+		assert.NoError(t, err)
 		time.Sleep(500 * time.Millisecond)
-		groupClient.PollFetches(nil)
-		groupClient2.PollFetches(nil)
+		groupClient.ForceMetadataRefresh()
+		groupClient2.ForceMetadataRefresh()
 		time.Sleep(500 * time.Millisecond)
 		startTopics, err := kadmCl.ListTopics(ctx)
 		assert.Contains(t, startTopics.TopicsList().Topics(), retryTopic.TopicName(config.Scope))

--- a/pubsubx/kgox/admin_client_impl_test.go
+++ b/pubsubx/kgox/admin_client_impl_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/clinia/x/pointerx"
+	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/samber/lo"
 	"github.com/segmentio/ksuid"
 	"github.com/stretchr/testify/assert"
@@ -16,8 +17,8 @@ import (
 )
 
 func TestKadminClient_CreateTopic(t *testing.T) {
+	config := getPubsubConfig(t, true)
 	getKadmClient := func(t *testing.T, defaultCreateTopicConfigs ...map[string]*string) (*KgoxAdminClient, *kadm.Client) {
-		config := getPubsubConfig(t, false)
 		wc, err := kgo.NewClient(
 			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
 		)
@@ -114,5 +115,145 @@ func TestKadminClient_CreateTopic(t *testing.T) {
 		kgoxAdmCl, _ := getKadmClient(t)
 		_, err := kgoxAdmCl.DescribeTopicConfigs(ctx)
 		require.NoError(t, err)
+	})
+}
+
+func TestKadminClient_DeleteGroup(t *testing.T) {
+	config := getPubsubConfig(t, true)
+	getKadmClient := func(t *testing.T, defaultCreateTopicConfigs ...map[string]*string) (*KgoxAdminClient, *kadm.Client) {
+		wc, err := kgo.NewClient(
+			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
+		)
+		require.NoError(t, err)
+		t.Cleanup(wc.Close)
+		var defaultCreateTopicConfigEntries map[string]*string
+		if len(defaultCreateTopicConfigs) > 0 {
+			defaultCreateTopicConfigEntries = lo.Assign(defaultCreateTopicConfigs...)
+		}
+
+		kadmCl := kadm.NewClient(wc)
+		return NewPubSubAdminClient(kadmCl, defaultCreateTopicConfigEntries), kadmCl
+	}
+
+	t.Run("test delete consumer group with retry topics", func(t *testing.T) {
+		ctx := context.Background()
+		kgoxAdmCl, kadmCl := getKadmClient(t)
+		group, topics := getRandomGroupTopics(t, 1)
+		retryTopic := topics[0].GenerateRetryTopic(messagex.ConsumerGroup(group))
+		_, err := kadmCl.CreateTopics(ctx, 1, 1, map[string]*string{}, topics[0].TopicName(config.Scope))
+		assert.NoError(t, err)
+		defer func() {
+			kadmCl.DeleteTopic(context.Background(), topics[0].TopicName(config.Scope))
+		}()
+		_, err = kadmCl.CreateTopics(ctx, 1, 1, map[string]*string{}, retryTopic.TopicName(config.Scope))
+		assert.NoError(t, err)
+		defer func() {
+			kadmCl.DeleteTopic(context.Background(), retryTopic.TopicName(config.Scope))
+		}()
+		groupClient, err := kgo.NewClient(
+			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
+			kgo.ConsumerGroup(group),
+			kgo.ConsumeTopics(topics[0].TopicName(config.Scope), retryTopic.TopicName(config.Scope)),
+		)
+		time.Sleep(500 * time.Millisecond)
+		groupClient.PollFetches(nil)
+		time.Sleep(500 * time.Millisecond)
+		startTopics, err := kadmCl.ListTopics(ctx)
+		assert.Contains(t, startTopics.TopicsList().Topics(), retryTopic.TopicName(config.Scope))
+		assert.NoError(t, err)
+		startGroups, err := kadmCl.ListGroups(ctx)
+		assert.Contains(t, startGroups.Groups(), group)
+		assert.NoError(t, err)
+		groupClient.Close()
+		assert.NoError(t, err)
+
+		_, err = kgoxAdmCl.DeleteGroup(ctx, group)
+
+		assert.NoError(t, err)
+		endTopics, err := kadmCl.ListTopics(ctx)
+		assert.NoError(t, err)
+		assert.NotContains(t, endTopics.TopicsList().Topics(), retryTopic.TopicName(config.Scope))
+		endGroups, err := kadmCl.ListGroups(ctx)
+		assert.NoError(t, err)
+		assert.NotContains(t, endGroups.Groups(), group)
+	})
+}
+
+func TestKadminClient_DeleteGroups(t *testing.T) {
+	config := getPubsubConfig(t, true)
+	getKadmClient := func(t *testing.T, defaultCreateTopicConfigs ...map[string]*string) (*KgoxAdminClient, *kadm.Client) {
+		wc, err := kgo.NewClient(
+			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
+		)
+		require.NoError(t, err)
+		t.Cleanup(wc.Close)
+		var defaultCreateTopicConfigEntries map[string]*string
+		if len(defaultCreateTopicConfigs) > 0 {
+			defaultCreateTopicConfigEntries = lo.Assign(defaultCreateTopicConfigs...)
+		}
+
+		kadmCl := kadm.NewClient(wc)
+		return NewPubSubAdminClient(kadmCl, defaultCreateTopicConfigEntries), kadmCl
+	}
+
+	t.Run("test delete consumer groups with retry topics", func(t *testing.T) {
+		ctx := context.Background()
+		kgoxAdmCl, kadmCl := getKadmClient(t)
+		group, topics := getRandomGroupTopics(t, 1)
+		group2, _ := getRandomGroupTopics(t, 0)
+		retryTopic := topics[0].GenerateRetryTopic(messagex.ConsumerGroup(group))
+		retryTopic2 := topics[0].GenerateRetryTopic(messagex.ConsumerGroup(group2))
+		_, err := kadmCl.CreateTopics(ctx, 1, 1, map[string]*string{}, topics[0].TopicName(config.Scope))
+		assert.NoError(t, err)
+		defer func() {
+			kadmCl.DeleteTopic(context.Background(), topics[0].TopicName(config.Scope))
+		}()
+		_, err = kadmCl.CreateTopics(ctx, 1, 1, map[string]*string{}, retryTopic.TopicName(config.Scope))
+		assert.NoError(t, err)
+		defer func() {
+			kadmCl.DeleteTopic(context.Background(), retryTopic.TopicName(config.Scope))
+		}()
+		_, err = kadmCl.CreateTopics(ctx, 1, 1, map[string]*string{}, retryTopic2.TopicName(config.Scope))
+		assert.NoError(t, err)
+		defer func() {
+			kadmCl.DeleteTopic(context.Background(), retryTopic2.TopicName(config.Scope))
+		}()
+		groupClient, err := kgo.NewClient(
+			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
+			kgo.ConsumerGroup(group),
+			kgo.ConsumeTopics(topics[0].TopicName(config.Scope), retryTopic.TopicName(config.Scope)),
+		)
+		groupClient2, err := kgo.NewClient(
+			kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
+			kgo.ConsumerGroup(group2),
+			kgo.ConsumeTopics(topics[0].TopicName(config.Scope), retryTopic.TopicName(config.Scope)),
+		)
+		time.Sleep(500 * time.Millisecond)
+		groupClient.PollFetches(nil)
+		groupClient2.PollFetches(nil)
+		time.Sleep(500 * time.Millisecond)
+		startTopics, err := kadmCl.ListTopics(ctx)
+		assert.Contains(t, startTopics.TopicsList().Topics(), retryTopic.TopicName(config.Scope))
+		assert.Contains(t, startTopics.TopicsList().Topics(), retryTopic2.TopicName(config.Scope))
+		assert.NoError(t, err)
+		startGroups, err := kadmCl.ListGroups(ctx)
+		assert.Contains(t, startGroups.Groups(), group)
+		assert.Contains(t, startGroups.Groups(), group2)
+		assert.NoError(t, err)
+		groupClient.Close()
+		groupClient2.Close()
+		assert.NoError(t, err)
+
+		_, err = kgoxAdmCl.DeleteGroups(ctx, group, group2)
+
+		assert.NoError(t, err)
+		endTopics, err := kadmCl.ListTopics(ctx)
+		assert.NoError(t, err)
+		assert.NotContains(t, endTopics.TopicsList().Topics(), retryTopic.TopicName(config.Scope))
+		assert.NotContains(t, endTopics.TopicsList().Topics(), retryTopic2.TopicName(config.Scope))
+		endGroups, err := kadmCl.ListGroups(ctx)
+		assert.NoError(t, err)
+		assert.NotContains(t, endGroups.Groups(), group)
+		assert.NotContains(t, endGroups.Groups(), group2)
 	})
 }

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -89,9 +89,13 @@ func (c *consumer) bootstrapClient() error {
 	if err != nil {
 		c.l.WithError(err).Warnf("event retry mechanism might not work properly")
 	}
-	scopedTopics := lo.Map(append(c.topics, retryTopics...), func(topic messagex.Topic, _ int) string {
-		return topic.TopicName(c.conf.Scope)
-	})
+	scopedTopics := make([]string, len(c.topics)+len(retryTopics))
+	for i, t := range c.topics {
+		scopedTopics[i] = t.TopicName(c.conf.Scope)
+	}
+	for i, t := range retryTopics {
+		scopedTopics[len(c.topics)+i] = t.TopicName(c.conf.Scope)
+	}
 	kopts := []kgo.Opt{
 		kgo.ConsumerGroup(c.group.ConsumerGroup(c.conf.Scope)),
 		kgo.SeedBrokers(c.conf.Providers.Kafka.Brokers...),

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -87,7 +87,7 @@ func (c *consumer) bootstrapClient() error {
 	}
 	retryTopics, _, err := c.erh.generateRetryTopics(context.Background(), c.topics...)
 	if err != nil {
-		c.l.WithError(err).Warnf("event retry mechanism might not work properly")
+		c.l.WithError(err).Errorf("event retry mechanism might not work properly")
 	}
 	scopedTopics := make([]string, len(c.topics)+len(retryTopics))
 	for i, t := range c.topics {

--- a/pubsubx/kgox/poison_queue_handler.go
+++ b/pubsubx/kgox/poison_queue_handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/clinia/x/errorx"
-	"github.com/clinia/x/pubsubx"
 	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -118,51 +117,4 @@ func (pqh *poisonQueueHandler) generatePoisonQueueRecord(ctx context.Context, to
 
 func (pqh *poisonQueueHandler) CanUsePoisonQueue() bool {
 	return pqh.conf != nil && pqh.conf.PoisonQueue.IsEnabled()
-}
-
-func (pqh *poisonQueueHandler) Consume(ctx context.Context, handlers pubsubx.Handlers, topicFilters ...string) ([]error, error) {
-	kopts := []kgo.Opt{
-		kgo.ConsumerGroup(messagex.ConsumerGroup(pqh.conf.PoisonQueue.TopicName + ".cg").ConsumerGroup(pqh.conf.Scope)),
-		kgo.SeedBrokers(pqh.conf.Providers.Kafka.Brokers...),
-		kgo.ConsumeTopics(messagex.Topic(pqh.conf.PoisonQueue.TopicName).TopicName(pqh.conf.Scope)),
-	}
-
-	if pqh.kotelService != nil {
-		kopts = append(kopts, kgo.WithHooks(pqh.kotelService.Hooks()...))
-	}
-
-	cl, err := kgo.NewClient(kopts...)
-
-	fetches := cl.PollFetches(ctx)
-
-	fetches.EachTopic(func(ft kgo.FetchTopic) {
-		ft.EachRecord(func(r *kgo.Record) {
-			msg, err := defaultMarshaler.Unmarshal(r)
-			if err != nil {
-				return
-			}
-			originTopic, ok := msg.Metadata[originTopicHeaderKey]
-			if !ok {
-				return
-			}
-			allowed := false
-			for _, f := range topicFilters {
-				if originTopic == f {
-					allowed = true
-					break
-				}
-			}
-			if !allowed {
-				return
-			}
-			var eventMessage messagex.Message
-			err = json.Unmarshal(msg.Payload, &eventMessage)
-			_, err = handlers[messagex.BaseTopicFromName(originTopic)](ctx, []*messagex.Message{&eventMessage})
-			if err != nil {
-				return
-			}
-		})
-	})
-
-	return []error{}, err
 }

--- a/pubsubx/kgox/pubsub.go
+++ b/pubsubx/kgox/pubsub.go
@@ -172,7 +172,7 @@ func (p *PubSub) AdminClient() (pubsubx.PubSubAdminClient, error) {
 		return nil, errorx.InternalErrorf("failed to create kafka client: %v", err)
 	}
 
-	admClient := NewPubSubAdminClient(kadm.NewClient(wc), p.defaultCreateTopicConfigEntries)
+	admClient := NewPubSubAdminClient(kadm.NewClient(wc), p.conf, p.defaultCreateTopicConfigEntries)
 	return admClient, nil
 }
 

--- a/pubsubx/messagex/topic.go
+++ b/pubsubx/messagex/topic.go
@@ -8,12 +8,12 @@ import (
 type Topic string
 
 const (
-	topicSeparator = "."
-	retrySuffix    = "retry"
+	TopicSeparator   = "."
+	TopicRetrySuffix = TopicSeparator + "retry"
 )
 
 func NewTopic(topic string) (Topic, error) {
-	if strings.Contains(string(topic), topicSeparator) {
+	if strings.Contains(string(topic), TopicSeparator) {
 		return "", fmt.Errorf("topic name cannot contain '.'")
 	}
 
@@ -25,20 +25,20 @@ func NewTopic(topic string) (Topic, error) {
 // This should be used when interacting with the concrete pubsubs (e.g. Kafka).
 func (t Topic) TopicName(scope string) string {
 	if scope != "" {
-		return scope + topicSeparator + string(t)
+		return scope + TopicSeparator + string(t)
 	}
 
 	return string(t)
 }
 
 func (t Topic) GenerateRetryTopic(consumerGroup ConsumerGroup) Topic {
-	return Topic(string(t) + topicSeparator + string(consumerGroup) + topicSeparator + retrySuffix)
+	return Topic(string(t) + TopicSeparator + string(consumerGroup) + TopicRetrySuffix)
 }
 
 func TopicFromName(topicName string) Topic {
-	splits := strings.Split(topicName, topicSeparator)
+	splits := strings.Split(topicName, TopicSeparator)
 	if len(splits) > 1 {
-		return Topic(strings.Join(splits[1:], topicSeparator))
+		return Topic(strings.Join(splits[1:], TopicSeparator))
 	}
 
 	return Topic(splits[0])
@@ -47,16 +47,16 @@ func TopicFromName(topicName string) Topic {
 // Expect topic to be format `{scope}.{topic}.{consumer-group}.retry` or `{scope}.{topic}`
 // If the scope is missing, this function will return a wrong result
 func BaseTopicFromName(topicName string) Topic {
-	splits := strings.Split(topicName, topicSeparator)
+	splits := strings.Split(topicName, TopicSeparator)
 	if len(splits) > 1 {
-		if strings.HasSuffix(splits[len(splits)-1], retrySuffix) {
+		if strings.HasSuffix(topicName, TopicRetrySuffix) {
 			if len(splits) > 2 {
-				return Topic(strings.Join(splits[1:len(splits)-2], topicSeparator))
+				return Topic(strings.Join(splits[1:len(splits)-2], TopicSeparator))
 			}
 			// Should not happen, this is the use case where the topic and the scope or not included
-			return Topic(strings.Join(splits[1:len(splits)-1], topicSeparator))
+			return Topic(strings.Join(splits[1:len(splits)-1], TopicSeparator))
 		}
-		return Topic(strings.Join(splits[1:], topicSeparator))
+		return Topic(strings.Join(splits[1:], TopicSeparator))
 	}
 
 	return Topic(splits[0])

--- a/pubsubx/messagex/topic_test.go
+++ b/pubsubx/messagex/topic_test.go
@@ -15,7 +15,7 @@ func TestNewTopic(t *testing.T) {
 	})
 
 	t.Run("should return error with invalid topic name", func(t *testing.T) {
-		topic, err := NewTopic("my" + topicSeparator + "topic")
+		topic, err := NewTopic("my" + TopicSeparator + "topic")
 		assert.Error(t, err)
 		assert.Equal(t, Topic(""), topic)
 	})
@@ -32,7 +32,7 @@ func TestTopicName(t *testing.T) {
 	t.Run("should return topic name with scope", func(t *testing.T) {
 		topic, err := NewTopic("my-topic")
 		require.NoError(t, err)
-		assert.Equal(t, "scope"+topicSeparator+"my-topic", topic.TopicName("scope"))
+		assert.Equal(t, "scope"+TopicSeparator+"my-topic", topic.TopicName("scope"))
 	})
 }
 
@@ -41,7 +41,7 @@ func TestGenerateRetryTopic(t *testing.T) {
 		topic, err := NewTopic("my-topic")
 		require.NoError(t, err)
 		retryTopic := topic.GenerateRetryTopic(ConsumerGroup("group"))
-		assert.Equal(t, "my-topic"+topicSeparator+"group"+topicSeparator+retrySuffix, string(retryTopic))
+		assert.Equal(t, "my-topic"+TopicSeparator+"group"+TopicRetrySuffix, string(retryTopic))
 	})
 }
 
@@ -79,17 +79,17 @@ func TestBaseTopicFromName(t *testing.T) {
 	})
 
 	t.Run("should return a topic extracted from a retry topic name without scope", func(t *testing.T) {
-		topic := BaseTopicFromName("scope.my-topic.interestingly.consumer-group." + retrySuffix)
+		topic := BaseTopicFromName("scope.my-topic.interestingly.consumer-group" + TopicRetrySuffix)
 		assert.Equal(t, Topic("my-topic.interestingly"), topic)
 	})
 
 	t.Run("should return a topic extracted from a short retry topic", func(t *testing.T) {
-		topic := BaseTopicFromName("scope.my-topic.consumer-group." + retrySuffix)
+		topic := BaseTopicFromName("scope.my-topic.consumer-group" + TopicRetrySuffix)
 		assert.Equal(t, Topic("my-topic"), topic)
 	})
 
 	t.Run("should return an empty topic extracted from a retry suffix only topic", func(t *testing.T) {
-		topic := BaseTopicFromName("consumer-group." + retrySuffix)
+		topic := BaseTopicFromName("consumer-group" + TopicRetrySuffix)
 		assert.Equal(t, Topic(""), topic)
 	})
 }


### PR DESCRIPTION
Implement DeleteGroup and DeleteGroups in the admin client of `kgox` to support deleting the retry topic assigned to the groups. Also add the `DeleteTopic(s)WithRetryTopics` to allow deleting all related topics if the main topic is deleted.