### PR TITLE
fix: refactor event retry logic in `kgox` to manually create the retry topic instead of relying on auto-retry

### DIFF
--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'pubsubx/kgox/**'
-      
+      - "pubsubx/kgox/**"
 
 jobs:
   tests:
@@ -15,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.21.1'
+          go-version: "^1.21.1"
       - run: cat .env >> $GITHUB_ENV || true
       - name: Setup Kafka
-        run: docker compose -f docker-compose.kgox.yml up -d --wait
+        run: docker compose -f docker-compose.kafka.kgox.yml up -d --wait
       - run: go run github.com/ThreeDotsLabs/wait-for@latest localhost:9091 localhost:9092 localhost:9093 localhost:9094 localhost:9095
       - run: make test_kafka
         env:

--- a/docker-compose.kafka.kgox.yml
+++ b/docker-compose.kafka.kgox.yml
@@ -1,0 +1,93 @@
+# for Watermill development purposes.
+# For Watermill based application docker please check https://watermill.io/docs/getting-started/
+
+version: "3"
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.1
+    restart: unless-stopped
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: "2181"
+      ZOOKEEPER_TICK_TIME: "2000"
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.3.1
+    depends_on:
+      - zookeeper
+    env_file:
+      - .docker/docker-kafka.env
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9091,INTERNAL://0.0.0.0:29091
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9091,INTERNAL://kafka1:29091
+      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+    ports:
+      - 9091:9091
+    restart: unless-stopped
+
+  kafka2:
+    image: confluentinc/cp-kafka:7.3.1
+    depends_on:
+      - zookeeper
+    env_file:
+      - .docker/docker-kafka.env
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9092,INTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9092,INTERNAL://kafka2:29092
+      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+    ports:
+      - 9092:9092
+    restart: unless-stopped
+
+  kafka3:
+    image: confluentinc/cp-kafka:7.3.1
+    depends_on:
+      - zookeeper
+    env_file:
+      - .docker/docker-kafka.env
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9093,INTERNAL://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9093,INTERNAL://kafka3:29093
+      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+    ports:
+      - 9093:9093
+    restart: unless-stopped
+
+  kafka4:
+    image: confluentinc/cp-kafka:7.3.1
+    depends_on:
+      - zookeeper
+    env_file:
+      - .docker/docker-kafka.env
+    environment:
+      KAFKA_BROKER_ID: 4
+      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9094,INTERNAL://0.0.0.0:29094
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9094,INTERNAL://kafka4:29094
+      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+    ports:
+      - 9094:9094
+    restart: unless-stopped
+
+  kafka5:
+    image: confluentinc/cp-kafka:7.3.1
+    depends_on:
+      - zookeeper
+    env_file:
+      - .docker/docker-kafka.env
+    environment:
+      KAFKA_BROKER_ID: 5
+      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9095,INTERNAL://0.0.0.0:29095
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9095,INTERNAL://kafka5:29095
+      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+    ports:
+      - 9095:9095
+    restart: unless-stopped

--- a/docker-compose.kgox.yml
+++ b/docker-compose.kgox.yml
@@ -1,93 +1,98 @@
-# for Watermill development purposes.
-# For Watermill based application docker please check https://watermill.io/docs/getting-started/
-
-version: "3"
-
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.1
-    restart: unless-stopped
-    environment:
-      ZOOKEEPER_SERVER_ID: 1
-      ZOOKEEPER_CLIENT_PORT: "2181"
-      ZOOKEEPER_TICK_TIME: "2000"
+  redpanda:
+    profiles:
+      - prevent-default-start
 
-  kafka1:
-    image: confluentinc/cp-kafka:7.3.1
-    depends_on:
-      - zookeeper
-    env_file:
-      - .docker/docker-kafka.env
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9091,INTERNAL://0.0.0.0:29091
-      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9091,INTERNAL://kafka1:29091
-      KAFKA_MESSAGE_MAX_BYTES: 200000000
-      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+  redpanda-0:
+    image: oci.clinia.dev/rp/redpandadata/redpanda:v24.2.5
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda-0:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr redpanda-0:33145
+      - --advertise-rpc-addr redpanda-0:33145
+      - --smp 1
+      - --memory 1G
+      - --mode dev-container
+      - --default-log-level=debug
+      - --set redpanda.auto_create_topics_enabled=false
     ports:
-      - 9091:9091
-    restart: unless-stopped
+      - 18081:18081
+      - 18082:18082
+      - 19092:19092
+      - 19644:9644
 
-  kafka2:
-    image: confluentinc/cp-kafka:7.3.1
-    depends_on:
-      - zookeeper
-    env_file:
-      - .docker/docker-kafka.env
-    environment:
-      KAFKA_BROKER_ID: 2
-      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9092,INTERNAL://0.0.0.0:29092
-      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9092,INTERNAL://kafka2:29092
-      KAFKA_MESSAGE_MAX_BYTES: 200000000
-      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+  redpanda-1:
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:29092
+      - --advertise-kafka-addr internal://redpanda-1:9092,external://localhost:29092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:28082
+      - --advertise-pandaproxy-addr internal://redpanda-1:8082,external://localhost:28082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:28081
+      - --rpc-addr redpanda-1:33145
+      - --advertise-rpc-addr redpanda-1:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+      - --seeds redpanda-0:33145
+    image: oci.clinia.dev/rp/redpandadata/redpanda:v24.2.5
+    container_name: redpanda-1
     ports:
-      - 9092:9092
-    restart: unless-stopped
-
-  kafka3:
-    image: confluentinc/cp-kafka:7.3.1
+      - 28081:28081
+      - 28082:28082
+      - 29092:29092
+      - 29644:9644
     depends_on:
-      - zookeeper
-    env_file:
-      - .docker/docker-kafka.env
-    environment:
-      KAFKA_BROKER_ID: 3
-      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9093,INTERNAL://0.0.0.0:29093
-      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9093,INTERNAL://kafka3:29093
-      KAFKA_MESSAGE_MAX_BYTES: 200000000
-      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+      - redpanda-0
+  redpanda-2:
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:39092
+      - --advertise-kafka-addr internal://redpanda-2:9092,external://localhost:39092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:38082
+      - --advertise-pandaproxy-addr internal://redpanda-2:8082,external://localhost:38082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:38081
+      - --rpc-addr redpanda-2:33145
+      - --advertise-rpc-addr redpanda-2:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+      - --seeds redpanda-0:33145
+    image: oci.clinia.dev/rp/redpandadata/redpanda:v24.2.5
+    container_name: redpanda-2
     ports:
-      - 9093:9093
-    restart: unless-stopped
-
-  kafka4:
-    image: confluentinc/cp-kafka:7.3.1
+      - 38081:38081
+      - 38082:38082
+      - 39092:39092
+      - 39644:9644
     depends_on:
-      - zookeeper
-    env_file:
-      - .docker/docker-kafka.env
+      - redpanda-0
+  redpanda-console:
+    image: oci.clinia.dev/rp/redpandadata/console:v2.7.2
+    entrypoint: /bin/sh
+    command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:
-      KAFKA_BROKER_ID: 4
-      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9094,INTERNAL://0.0.0.0:29094
-      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9094,INTERNAL://kafka4:29094
-      KAFKA_MESSAGE_MAX_BYTES: 200000000
-      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["redpanda-0:9092", "redpanda-1:9092", "redpanda-2:9092"]
+          schemaRegistry:
+            enabled: true
+            urls: ["http://redpanda-0:8081", "http://redpanda-1:8081", "http://redpanda-2:8081"]
+        redpanda:
+          adminApi:
+            enabled: true
+            urls: ["http://redpanda-0:9644", "http://redpanda-1:9644", "http://redpanda-2:9644"]
+        server:
+          listenPort: 8081
     ports:
-      - 9094:9094
-    restart: unless-stopped
-
-  kafka5:
-    image: confluentinc/cp-kafka:7.3.1
+      - 8081:8081
     depends_on:
-      - zookeeper
-    env_file:
-      - .docker/docker-kafka.env
-    environment:
-      KAFKA_BROKER_ID: 5
-      KAFKA_LISTENERS: EXTERNAL://0.0.0.0:9095,INTERNAL://0.0.0.0:29095
-      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:9095,INTERNAL://kafka5:29095
-      KAFKA_MESSAGE_MAX_BYTES: 200000000
-      KAFKA_REPLICA_FETCH_MAX_BYTES: 200000000
-    ports:
-      - 9095:9095
-    restart: unless-stopped
+      - redpanda-0

--- a/pubsubx/admin_client.go
+++ b/pubsubx/admin_client.go
@@ -10,6 +10,9 @@ type PubSubAdminClient interface {
 	// CreateTopic creates a topic with the given configuration.
 	// The default configuration entries are set by default, but they can be overridden (see `pubsub.NewCreateTopicConfigEntries()`).
 	CreateTopic(ctx context.Context, partitions int32, replicationFactor int16, topic string, configs ...map[string]*string) (kadm.CreateTopicResponse, error)
+	// CreateTopics creates a topics with the given configuration.
+	// The default configuration entries are set by default, but they can be overridden (see `pubsub.NewCreateTopicConfigEntries()`).
+	CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, topics []string, configs ...map[string]*string) (kadm.CreateTopicResponses, error)
 	// DeleteTopic deletes a topic.
 	DeleteTopic(ctx context.Context, topic string) (kadm.DeleteTopicResponse, error)
 	// HealthCheck checks the health of the underlying pubsub. It returns an error if the pubsub is unhealthy or we cannot connect to it.

--- a/pubsubx/inmemory/noop_admin_client.go
+++ b/pubsubx/inmemory/noop_admin_client.go
@@ -46,6 +46,32 @@ func (n *NoopAdminClient) CreateTopic(ctx context.Context, partitions int32, rep
 	}, nil
 }
 
+// CreateTopic implements pubsubx.PubSubAdminClient.
+func (n *NoopAdminClient) CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, topics []string, configs ...map[string]*string) (kadm.CreateTopicResponses, error) {
+	pDetails := kadm.PartitionDetails{}
+	res := make(kadm.CreateTopicResponses)
+	for _, t := range topics {
+		for i := range partitions {
+			pDetails[i] = kadm.PartitionDetail{
+				Topic:     t,
+				Partition: i,
+				Replicas:  make([]int32, replicationFactor),
+			}
+		}
+		n.topics[t] = kadm.TopicDetail{
+			Topic:      t,
+			Partitions: pDetails,
+		}
+		res[t] = kadm.CreateTopicResponse{
+			Topic:             t,
+			NumPartitions:     partitions,
+			ReplicationFactor: replicationFactor,
+		}
+	}
+
+	return res, nil
+}
+
 // DeleteTopic implements pubsubx.PubSubAdminClient.
 func (n *NoopAdminClient) DeleteTopic(ctx context.Context, topic string) (kadm.DeleteTopicResponse, error) {
 	delete(n.topics, topic)

--- a/pubsubx/kgox/admin_client_impl.go
+++ b/pubsubx/kgox/admin_client_impl.go
@@ -31,6 +31,17 @@ func (p *KgoxAdminClient) CreateTopic(ctx context.Context, partitions int32, rep
 	return p.Client.CreateTopic(ctx, partitions, replicationFactor, conf, topic)
 }
 
+// CreateTopics implements PubSubAdminClient.
+// Subtle: this method shadows the method (*Client).CreateTopics of pubsubAdminClient.Client.
+func (p *KgoxAdminClient) CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, topics []string, configs ...map[string]*string) (kadm.CreateTopicResponses, error) {
+	configMaps := append([]map[string]*string{p.defaultCreateTopicConfigEntries}, configs...)
+	configMaps = lo.Filter(configMaps, func(m map[string]*string, i int) bool {
+		return m != nil
+	})
+	conf := lo.Assign(configMaps...)
+	return p.Client.CreateTopics(ctx, partitions, replicationFactor, conf, topics...)
+}
+
 // HealthCheck implements pubsubx.PubSubAdminClient.
 func (p *KgoxAdminClient) HealthCheck(ctx context.Context) error {
 	_, err := p.ListBrokers(ctx)

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -3,8 +3,6 @@ package kgox
 import (
 	"context"
 	"errors"
-	"slices"
-	"strconv"
 	"sync"
 	"time"
 
@@ -22,16 +20,16 @@ import (
 )
 
 type consumer struct {
-	l                  *logrusx.Logger
-	cl                 *kgo.Client
-	conf               *pubsubx.Config
-	group              messagex.ConsumerGroup
-	topics             []messagex.Topic
-	retryTopics        []messagex.Topic
-	opts               *pubsubx.SubscriberOptions
-	handlers           pubsubx.Handlers
-	kotelService       *kotel.Kotel
-	poisonQueueHandler PoisonQueueHandler
+	l            *logrusx.Logger
+	cl           *kgo.Client
+	conf         *pubsubx.Config
+	group        messagex.ConsumerGroup
+	topics       []messagex.Topic
+	opts         *pubsubx.SubscriberOptions
+	handlers     pubsubx.Handlers
+	kotelService *kotel.Kotel
+	erh          *eventRetryHandler
+	pqh          PoisonQueueHandler
 
 	mu     sync.RWMutex
 	cancel context.CancelFunc
@@ -41,10 +39,6 @@ type consumer struct {
 
 var _ pubsubx.Subscriber = (*consumer)(nil)
 
-type contextLoggerKey string
-
-const ctxLoggerKey contextLoggerKey = "consumer_logger"
-
 const (
 	// We do not want to have a max elapsed time as we are counting on `maxRetryCount` to stop retrying
 	maxElapsedTime = 0
@@ -53,7 +47,7 @@ const (
 	maxRetryCount    = 3
 )
 
-func newConsumer(l *logrusx.Logger, kotelService *kotel.Kotel, config *pubsubx.Config, group string, topics []messagex.Topic, opts *pubsubx.SubscriberOptions, poisonQueueHandler PoisonQueueHandler) (*consumer, error) {
+func newConsumer(l *logrusx.Logger, kotelService *kotel.Kotel, config *pubsubx.Config, group messagex.ConsumerGroup, topics []messagex.Topic, opts *pubsubx.SubscriberOptions, erh *eventRetryHandler, pqh PoisonQueueHandler) (*consumer, error) {
 	if l == nil {
 		return nil, errorx.FailedPreconditionErrorf("logger is required")
 	}
@@ -62,15 +56,7 @@ func newConsumer(l *logrusx.Logger, kotelService *kotel.Kotel, config *pubsubx.C
 		opts = pubsubx.NewDefaultSubscriberOptions()
 	}
 
-	consumerGroup := messagex.ConsumerGroup(group)
-	retryTopics := make([]messagex.Topic, 0)
-	if config.TopicRetry && opts.MaxTopicRetryCount > 0 {
-		retryTopics = lo.Map(topics, func(topic messagex.Topic, _ int) messagex.Topic {
-			return topic.GenerateRetryTopic(consumerGroup)
-		})
-	}
-
-	cons := &consumer{l: l, kotelService: kotelService, group: consumerGroup, conf: config, topics: topics, retryTopics: retryTopics, opts: opts, poisonQueueHandler: poisonQueueHandler}
+	cons := &consumer{l: l, kotelService: kotelService, group: group, conf: config, topics: topics, opts: opts, erh: erh, pqh: pqh}
 
 	if err := cons.bootstrapClient(); err != nil {
 		return nil, err
@@ -96,14 +82,13 @@ func (c *consumer) attributes(topic *messagex.Topic) []attribute.KeyValue {
 }
 
 func (c *consumer) bootstrapClient() error {
-	scopedTopics := lo.Map(append(c.topics, c.retryTopics...), func(topic messagex.Topic, _ int) string {
+	scopedTopics := lo.Map(append(c.topics, c.erh.generateRetryTopics(context.Background(), c.topics...)...), func(topic messagex.Topic, _ int) string {
 		return topic.TopicName(c.conf.Scope)
 	})
 	kopts := []kgo.Opt{
 		kgo.ConsumerGroup(c.group.ConsumerGroup(c.conf.Scope)),
 		kgo.SeedBrokers(c.conf.Providers.Kafka.Brokers...),
 		kgo.ConsumeTopics(scopedTopics...),
-		kgo.AllowAutoTopicCreation(),
 	}
 
 	if c.kotelService != nil {
@@ -259,65 +244,23 @@ func (c *consumer) start(ctx context.Context) {
 	}
 }
 
-func (c *consumer) canTopicRetry() bool {
-	return c.conf != nil && c.conf.TopicRetry && c.opts != nil && c.opts.MaxTopicRetryCount > 0
-}
-
-func (c *consumer) canUsePoisonQueue() bool {
-	return c.conf != nil && c.conf.PoisonQueue.IsEnabled()
-}
-
-// getContextLogger allows to extract the logger set in the context if we have some contextual logger
-// that is used
-func (c *consumer) getContexLogger(ctx context.Context) (l *logrusx.Logger) {
-	if ctxL := ctx.Value(ctxLoggerKey); ctxL != nil {
-		if ctxL, ok := ctxL.(*logrusx.Logger); ok {
-			l = ctxL
-		}
-	}
-	if l == nil {
-		l = c.l
-	}
-	return
-}
-
 func (c *consumer) handleRemoteRetryLogic(ctx context.Context, topic messagex.Topic, errs []error, msgs []*messagex.Message) {
-	l := c.getContexLogger(ctx)
-	if !c.canTopicRetry() && !c.canUsePoisonQueue() {
+	l := getContexLogger(ctx, c.l)
+	if !c.erh.canTopicRetry() && !c.pqh.CanUsePoisonQueue() {
 		l.Debugf("topic retry and poison queue are disable, not exeucting retry logic")
 		return
 	}
-	retryableMessages, poisonQueueMessages, poisonQueueErrs := c.parseRetryMessages(ctx, errs, msgs)
-	if c.canTopicRetry() && len(retryableMessages) > 0 {
-		if publishErr := c.publishRetryMessages(ctx, retryableMessages, topic); publishErr != nil {
+	retryableMessages, poisonQueueMessages, poisonQueueErrs := c.erh.parseRetryMessages(ctx, errs, msgs)
+	if c.erh.canTopicRetry() && len(retryableMessages) > 0 {
+		if publishErr := c.erh.publishRetryMessages(ctx, retryableMessages, topic); publishErr != nil {
 			l.WithError(publishErr).Errorf("failed to publish as some or all retry messages")
 		}
 	}
-	if c.canUsePoisonQueue() && len(poisonQueueMessages) > 0 {
+	if c.pqh.CanUsePoisonQueue() && len(poisonQueueMessages) > 0 {
 		if publishErr := c.publishPoisonQueueMessages(ctx, topic, poisonQueueMessages, poisonQueueErrs); publishErr != nil {
 			l.WithError(publishErr).Errorf("failed to publish some or all retry messages to the poison queue")
 		}
 	}
-}
-
-func (c *consumer) publishRetryMessages(ctx context.Context, retryableMessages []*messagex.Message, topic messagex.Topic) error {
-	retryRecords := make([]*kgo.Record, len(retryableMessages))
-	marshalErrs := make(pubsubx.Errors, len(retryableMessages))
-	scopedTopic := topic.GenerateRetryTopic(c.group).TopicName(c.conf.Scope)
-	for i, m := range retryableMessages {
-		retryRecords[i], marshalErrs[i] = defaultMarshaler.Marshal(ctx, m, scopedTopic)
-	}
-	marshalErr := errors.Join(marshalErrs...)
-	retryRecords = slices.DeleteFunc(retryRecords, func(r *kgo.Record) bool {
-		return r == nil
-	})
-	produceResults := c.cl.ProduceSync(ctx, retryRecords...)
-	produceErrs := make(pubsubx.Errors, len(produceResults))
-	for i, record := range produceResults {
-		produceErrs[i] = record.Err
-	}
-	produceErr := errors.Join(produceErrs...)
-	return errors.Join(marshalErr, produceErr)
 }
 
 func (c *consumer) publishPoisonQueueMessages(ctx context.Context, topic messagex.Topic, msgs []*messagex.Message, errs []error) error {
@@ -328,69 +271,10 @@ func (c *consumer) publishPoisonQueueMessages(ctx context.Context, topic message
 		localErrs = []error{}
 	}
 	if len(errs) == 1 {
-		return c.poisonQueueHandler.PublishMessagesToPoisonQueueWithGenericError(ctx, topicName, c.group, errs[0], msgs...)
+		return c.pqh.PublishMessagesToPoisonQueueWithGenericError(ctx, topicName, c.group, errs[0], msgs...)
 	} else {
-		return c.poisonQueueHandler.PublishMessagesToPoisonQueue(ctx, topicName, c.group, localErrs, msgs)
+		return c.pqh.PublishMessagesToPoisonQueue(ctx, topicName, c.group, localErrs, msgs)
 	}
-}
-
-func (c *consumer) parseRetryMessages(ctx context.Context, errs []error, allMsgs []*messagex.Message) ([]*messagex.Message, []*messagex.Message, []error) {
-	l := c.getContexLogger(ctx)
-	retryableMessages := make([]*messagex.Message, 0)
-	poisonQueueMessages := make([]*messagex.Message, 0)
-	poisonQueueErrs := make([]error, 0)
-
-	checkErrs := len(errs) == len(allMsgs)
-	retryable := false
-	var referErr error
-	if !checkErrs {
-		if len(errs) == 1 {
-			l.Debugf("using first error as reference to if we should retry the batch")
-			_, retryable = errorx.IsRetryableError(errs[0])
-			referErr = errs[0]
-		} else {
-			l.Warnf("errors handler result mismatch messages length, can't identify which message failed, sending them all back")
-		}
-	}
-	for i, msg := range allMsgs {
-		if msg == nil {
-			continue
-		}
-		localRetryable := retryable
-		if checkErrs {
-			referErr = errs[i]
-			if referErr == nil {
-				continue
-			}
-			_, localRetryable = errorx.IsRetryableError(referErr)
-		}
-		copiedMsg := msg.Copy()
-		if !localRetryable {
-			if c.canUsePoisonQueue() {
-				poisonQueueMessages = append(poisonQueueMessages, copiedMsg)
-				poisonQueueErrs = append(poisonQueueErrs, referErr)
-			}
-			continue
-		}
-		retryCount, ok := msg.Metadata[messagex.RetryCountHeaderKey]
-		if !ok {
-			l.Warnf("message is missing %s header, setting it to '1'", messagex.RetryCountHeaderKey)
-			copiedMsg.Metadata[messagex.RetryCountHeaderKey] = "1"
-		} else {
-			numericRetryCount, err := strconv.Atoi(retryCount)
-			if !c.canTopicRetry() || err != nil || numericRetryCount >= int(c.opts.MaxTopicRetryCount)-1 {
-				l.Errorf("not retrying, adding message to poison queue messages")
-				if c.canUsePoisonQueue() {
-					poisonQueueMessages = append(poisonQueueMessages, copiedMsg)
-					poisonQueueErrs = append(poisonQueueErrs, referErr)
-				}
-				continue
-			}
-			copiedMsg.Metadata[messagex.RetryCountHeaderKey] = strconv.Itoa(numericRetryCount + 1)
-		}
-		retryableMessages = append(retryableMessages, copiedMsg)
-	}
-	return retryableMessages, poisonQueueMessages, poisonQueueErrs
 }
 
 // Subscribe implements pubsubx.Subscriber.

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -82,7 +82,11 @@ func (c *consumer) attributes(topic *messagex.Topic) []attribute.KeyValue {
 }
 
 func (c *consumer) bootstrapClient() error {
-	scopedTopics := lo.Map(append(c.topics, c.erh.generateRetryTopics(context.Background(), c.topics...)...), func(topic messagex.Topic, _ int) string {
+	retryTopics, _, err := c.erh.generateRetryTopics(context.Background(), c.topics...)
+	if err != nil {
+		c.l.WithError(err).Warnf("event retry mechanism might not work properly")
+	}
+	scopedTopics := lo.Map(append(c.topics, retryTopics...), func(topic messagex.Topic, _ int) string {
 		return topic.TopicName(c.conf.Scope)
 	})
 	kopts := []kgo.Opt{

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -82,6 +82,9 @@ func (c *consumer) attributes(topic *messagex.Topic) []attribute.KeyValue {
 }
 
 func (c *consumer) bootstrapClient() error {
+	if c.erh == nil {
+		return errorx.InternalErrorf("EventRetryHandler should not be nil in the consumer")
+	}
 	retryTopics, _, err := c.erh.generateRetryTopics(context.Background(), c.topics...)
 	if err != nil {
 		c.l.WithError(err).Warnf("event retry mechanism might not work properly")
@@ -250,6 +253,10 @@ func (c *consumer) start(ctx context.Context) {
 
 func (c *consumer) handleRemoteRetryLogic(ctx context.Context, topic messagex.Topic, errs []error, msgs []*messagex.Message) {
 	l := getContexLogger(ctx, c.l)
+	if c.erh == nil {
+		l.Errorf("EventRetryHandler should not be nil in the consumer")
+		return
+	}
 	if !c.erh.canTopicRetry() && !c.pqh.CanUsePoisonQueue() {
 		l.Debugf("topic retry and poison queue are disable, not exeucting retry logic")
 		return

--- a/pubsubx/kgox/event_retry_handler.go
+++ b/pubsubx/kgox/event_retry_handler.go
@@ -1,0 +1,144 @@
+package kgox
+
+import (
+	"context"
+	"errors"
+	"math"
+	"slices"
+	"strconv"
+
+	"github.com/clinia/x/errorx"
+	"github.com/clinia/x/pubsubx"
+	"github.com/clinia/x/pubsubx/messagex"
+	"github.com/samber/lo"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type eventRetryHandler struct {
+	*PubSub
+	consumerGroup messagex.ConsumerGroup
+	opts          *pubsubx.SubscriberOptions
+}
+
+func (erh *eventRetryHandler) generateRetryTopics(ctx context.Context, topics ...messagex.Topic) []messagex.Topic {
+	if !erh.conf.TopicRetry || erh.opts.MaxTopicRetryCount <= 0 || len(topics) == 0 {
+		erh.l.Debugf("not generating any retry topics, configuration is either disable, max topic count is <= 0 or no topic are passed in")
+		return []messagex.Topic{}
+	}
+	retryTopics := lo.Map(topics, func(topic messagex.Topic, _ int) messagex.Topic {
+		return topic.GenerateRetryTopic(erh.consumerGroup)
+	})
+
+	pbac, err := erh.AdminClient()
+	if err != nil {
+		erh.l.WithError(err).Errorf("failed to generate admin client on retry topic creation")
+		return []messagex.Topic{}
+	}
+	var replicationFactor int16 = math.MaxInt16
+	if len(erh.conf.Providers.Kafka.Brokers) <= math.MaxInt16 {
+		//nolint:all
+		replicationFactor = int16(len(erh.conf.Providers.Kafka.Brokers))
+	}
+
+	scopedRetryTopics := lo.Map(retryTopics, func(retryTopic messagex.Topic, _ int) string {
+		return retryTopic.TopicName(erh.conf.Scope)
+	})
+	res, err := pbac.CreateTopics(ctx, 1, replicationFactor, scopedRetryTopics, erh.defaultCreateTopicConfigEntries)
+	if err != nil {
+		erh.l.WithError(err).Errorf("failed to execute retry topic creation")
+		return []messagex.Topic{}
+	}
+	return lo.Filter(retryTopics, func(retryTopic messagex.Topic, _ int) bool {
+		scopeTopic := retryTopic.TopicName(erh.conf.Scope)
+		tr, ok := res[scopeTopic]
+		if !ok {
+			erh.l.Errorf("retry topic [%s] not included in topic creation response", scopeTopic)
+			return false
+		}
+		if tr.Err != nil && tr.Err.Error() != kerr.TopicAlreadyExists.Error() {
+			erh.l.WithError(tr.Err).Errorf("failed to create retry topic [%s]", scopeTopic)
+			return false
+		}
+		return true
+	})
+}
+
+func (c *eventRetryHandler) canTopicRetry() bool {
+	return c.conf != nil && c.conf.TopicRetry && c.opts != nil && c.opts.MaxTopicRetryCount > 0
+}
+
+func (c *eventRetryHandler) parseRetryMessages(ctx context.Context, errs []error, allMsgs []*messagex.Message) ([]*messagex.Message, []*messagex.Message, []error) {
+	l := getContexLogger(ctx, c.l)
+	retryableMessages := make([]*messagex.Message, 0)
+	poisonQueueMessages := make([]*messagex.Message, 0)
+	poisonQueueErrs := make([]error, 0)
+
+	checkErrs := len(errs) == len(allMsgs)
+	retryable := false
+	var referErr error
+	if !checkErrs {
+		if len(errs) == 1 {
+			l.Debugf("using first error as reference to if we should retry the batch")
+			_, retryable = errorx.IsRetryableError(errs[0])
+			referErr = errs[0]
+		} else {
+			l.Warnf("errors handler result mismatch messages length, can't identify which message failed, sending them all back")
+		}
+	}
+	for i, msg := range allMsgs {
+		if msg == nil {
+			continue
+		}
+		localRetryable := retryable
+		if checkErrs {
+			referErr = errs[i]
+			if referErr == nil {
+				continue
+			}
+			_, localRetryable = errorx.IsRetryableError(referErr)
+		}
+		copiedMsg := msg.Copy()
+		if !localRetryable {
+			poisonQueueMessages = append(poisonQueueMessages, copiedMsg)
+			poisonQueueErrs = append(poisonQueueErrs, referErr)
+			continue
+		}
+		retryCount, ok := msg.Metadata[messagex.RetryCountHeaderKey]
+		if !ok {
+			l.Warnf("message is missing %s header, setting it to '1'", messagex.RetryCountHeaderKey)
+			copiedMsg.Metadata[messagex.RetryCountHeaderKey] = "1"
+		} else {
+			numericRetryCount, err := strconv.Atoi(retryCount)
+			if !c.canTopicRetry() || err != nil || numericRetryCount >= int(c.opts.MaxTopicRetryCount)-1 {
+				l.Errorf("not retrying, adding message to poison queue messages")
+				poisonQueueMessages = append(poisonQueueMessages, copiedMsg)
+				poisonQueueErrs = append(poisonQueueErrs, referErr)
+				continue
+			}
+			copiedMsg.Metadata[messagex.RetryCountHeaderKey] = strconv.Itoa(numericRetryCount + 1)
+		}
+		retryableMessages = append(retryableMessages, copiedMsg)
+	}
+	return retryableMessages, poisonQueueMessages, poisonQueueErrs
+}
+
+func (c *eventRetryHandler) publishRetryMessages(ctx context.Context, retryableMessages []*messagex.Message, topic messagex.Topic) error {
+	retryRecords := make([]*kgo.Record, len(retryableMessages))
+	marshalErrs := make(pubsubx.Errors, len(retryableMessages))
+	scopedTopic := topic.GenerateRetryTopic(c.consumerGroup).TopicName(c.conf.Scope)
+	for i, m := range retryableMessages {
+		retryRecords[i], marshalErrs[i] = defaultMarshaler.Marshal(ctx, m, scopedTopic)
+	}
+	marshalErr := errors.Join(marshalErrs...)
+	retryRecords = slices.DeleteFunc(retryRecords, func(r *kgo.Record) bool {
+		return r == nil
+	})
+	produceResults := c.writeClient.ProduceSync(ctx, retryRecords...)
+	produceErrs := make(pubsubx.Errors, len(produceResults))
+	for i, record := range produceResults {
+		produceErrs[i] = record.Err
+	}
+	produceErr := errors.Join(produceErrs...)
+	return errors.Join(marshalErr, produceErr)
+}

--- a/pubsubx/kgox/event_retry_handler.go
+++ b/pubsubx/kgox/event_retry_handler.go
@@ -22,7 +22,7 @@ type eventRetryHandler struct {
 }
 
 func (erh *eventRetryHandler) generateRetryTopics(ctx context.Context, topics ...messagex.Topic) ([]messagex.Topic, []error, error) {
-	if !erh.conf.TopicRetry || erh.opts.MaxTopicRetryCount <= 0 || len(topics) == 0 {
+	if !erh.canTopicRetry() || len(topics) == 0 {
 		erh.l.Debugf("not generating any retry topics, configuration is either disable, max topic count is <= 0 or no topic are passed in")
 		return []messagex.Topic{}, []error{}, nil
 	}

--- a/pubsubx/kgox/event_retry_handler_test.go
+++ b/pubsubx/kgox/event_retry_handler_test.go
@@ -41,6 +41,7 @@ func TestGenerateRetryTopics(t *testing.T) {
 		erh := getEventRetryHandler(t, l, config, cg, nil)
 		cl, err := erh.AdminClient()
 		require.NoError(t, err)
+		//nolint:all
 		_, err = cl.CreateTopic(context.Background(), 1, int16(len(config.Providers.Kafka.Brokers)), string(topics[1].GenerateRetryTopic(cg)))
 		assert.NoError(t, err)
 		retryTopics, errs, err := erh.generateRetryTopics(context.Background(), topics...)

--- a/pubsubx/kgox/event_retry_handler_test.go
+++ b/pubsubx/kgox/event_retry_handler_test.go
@@ -1,0 +1,82 @@
+package kgox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/clinia/x/logrusx"
+	"github.com/clinia/x/pubsubx/messagex"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRetryTopics(t *testing.T) {
+	l := logrusx.New("test", "")
+	config := getPubsubConfig(t, true)
+
+	t.Run("should create retry topic for the topic list", func(t *testing.T) {
+		group, topics := getRandomGroupTopics(t, 4)
+		cg := messagex.ConsumerGroup(group)
+		erh := getEventRetryHandler(t, l, config, cg, nil)
+		retryTopics, errs, err := erh.generateRetryTopics(context.Background(), topics...)
+		t.Cleanup(func() {
+			cl, err := erh.AdminClient()
+			require.NoError(t, err)
+			for _, rt := range retryTopics {
+				cl.DeleteTopic(context.Background(), rt.TopicName(config.Scope))
+			}
+			cl.Close()
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, lo.Filter(errs, func(item error, _ int) bool { return item != nil }))
+		assert.Equal(t, lo.Map(topics, func(t messagex.Topic, _ int) messagex.Topic {
+			return t.GenerateRetryTopic(cg)
+		}), retryTopics)
+	})
+
+	t.Run("should create non-existing retry topic for the topic list", func(t *testing.T) {
+		group, topics := getRandomGroupTopics(t, 4)
+		cg := messagex.ConsumerGroup(group)
+		erh := getEventRetryHandler(t, l, config, cg, nil)
+		cl, err := erh.AdminClient()
+		require.NoError(t, err)
+		_, err = cl.CreateTopic(context.Background(), 1, int16(len(config.Providers.Kafka.Brokers)), string(topics[1].GenerateRetryTopic(cg)))
+		assert.NoError(t, err)
+		retryTopics, errs, err := erh.generateRetryTopics(context.Background(), topics...)
+		t.Cleanup(func() {
+			for _, rt := range retryTopics {
+				cl.DeleteTopic(context.Background(), rt.TopicName(config.Scope))
+			}
+			cl.Close()
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, lo.Filter(errs, func(item error, _ int) bool { return item != nil }))
+		assert.Equal(t, lo.Map(topics, func(t messagex.Topic, _ int) messagex.Topic {
+			return t.GenerateRetryTopic(cg)
+		}), retryTopics)
+	})
+
+	t.Run("should return only valid retry topics", func(t *testing.T) {
+		group, topics := getRandomGroupTopics(t, 4)
+		topics = append(topics, messagex.Topic("wrong name ~ `"))
+		cg := messagex.ConsumerGroup(group)
+		erh := getEventRetryHandler(t, l, config, cg, nil)
+		retryTopics, errs, err := erh.generateRetryTopics(context.Background(), topics...)
+		t.Cleanup(func() {
+			cl, err := erh.AdminClient()
+			require.NoError(t, err)
+			for _, rt := range retryTopics {
+				cl.DeleteTopic(context.Background(), rt.TopicName(config.Scope))
+			}
+			cl.Close()
+		})
+		assert.Error(t, err)
+		remainingErrs := lo.Filter(errs, func(item error, _ int) bool { return item != nil })
+		assert.Equal(t, 1, len(remainingErrs))
+		assert.Equal(t, lo.Map(topics[:len(topics)-1], func(t messagex.Topic, _ int) messagex.Topic {
+			return t.GenerateRetryTopic(cg)
+		}), retryTopics)
+		assert.Equal(t, len(topics)-1, len(retryTopics))
+	})
+}

--- a/pubsubx/kgox/poison_queue_handler.go
+++ b/pubsubx/kgox/poison_queue_handler.go
@@ -15,6 +15,7 @@ type poisonQueueHandler PubSub
 type PoisonQueueHandler interface {
 	PublishMessagesToPoisonQueue(ctx context.Context, topic string, consumerGroup messagex.ConsumerGroup, msgErrs []error, msgs []*messagex.Message) error
 	PublishMessagesToPoisonQueueWithGenericError(ctx context.Context, topic string, consumerGroup messagex.ConsumerGroup, msgErr error, msgs ...*messagex.Message) error
+	CanUsePoisonQueue() bool
 }
 
 var _ PoisonQueueHandler = (*poisonQueueHandler)(nil)
@@ -112,4 +113,8 @@ func (pqh *poisonQueueHandler) generatePoisonQueueRecord(ctx context.Context, to
 		return nil, err
 	}
 	return pqr, nil
+}
+
+func (pqh *poisonQueueHandler) CanUsePoisonQueue() bool {
+	return pqh.conf != nil && pqh.conf.PoisonQueue.IsEnabled()
 }

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -40,7 +40,8 @@ func getRandomGroupTopics(t *testing.T, count int) (Group string, Topics []messa
 
 func getPubsubConfig(t *testing.T, retry bool) *pubsubx.Config {
 	t.Helper()
-	kafkaURLs := []string{"localhost:9091", "localhost:9092", "localhost:9093", "localhost:9094", "localhost:9095"}
+
+	kafkaURLs := []string{"localhost:19092", "localhost:29092", "localhost:39092"}
 	kafkaURLsFromEnv := os.Getenv("KAFKA")
 	if len(kafkaURLsFromEnv) > 0 {
 		kafkaURLs = strings.Split(kafkaURLsFromEnv, ",")
@@ -102,6 +103,14 @@ func getPublisher(t *testing.T, l *logrusx.Logger, conf *pubsubx.Config) *publis
 	require.NoError(t, err)
 
 	return pubSub.Publisher().(*publisher)
+}
+
+func getEventRetryHandler(t *testing.T, l *logrusx.Logger, conf *pubsubx.Config, group messagex.ConsumerGroup, opts *pubsubx.SubscriberOptions) *eventRetryHandler {
+	t.Helper()
+	pubSub, err := NewPubSub(l, conf, nil)
+	require.NoError(t, err)
+
+	return pubSub.eventRetryHandler(group, opts)
 }
 
 func getPoisonQueueHandler(t *testing.T, l *logrusx.Logger, conf *pubsubx.Config) *poisonQueueHandler {

--- a/pubsubx/messagex/topic_test.go
+++ b/pubsubx/messagex/topic_test.go
@@ -79,12 +79,17 @@ func TestBaseTopicFromName(t *testing.T) {
 	})
 
 	t.Run("should return a topic extracted from a retry topic name without scope", func(t *testing.T) {
-		topic := BaseTopicFromName("scope.my-topic.interestingly.consumer-group" + retrySuffix)
+		topic := BaseTopicFromName("scope.my-topic.interestingly.consumer-group." + retrySuffix)
 		assert.Equal(t, Topic("my-topic.interestingly"), topic)
 	})
 
 	t.Run("should return a topic extracted from a short retry topic", func(t *testing.T) {
-		topic := BaseTopicFromName("scope.my-topic.consumer-group" + retrySuffix)
+		topic := BaseTopicFromName("scope.my-topic.consumer-group." + retrySuffix)
 		assert.Equal(t, Topic("my-topic"), topic)
+	})
+
+	t.Run("should return an empty topic extracted from a retry suffix only topic", func(t *testing.T) {
+		topic := BaseTopicFromName("consumer-group." + retrySuffix)
+		assert.Equal(t, Topic(""), topic)
 	})
 }

--- a/pubsubx/messagex/topic_test.go
+++ b/pubsubx/messagex/topic_test.go
@@ -41,7 +41,7 @@ func TestGenerateRetryTopic(t *testing.T) {
 		topic, err := NewTopic("my-topic")
 		require.NoError(t, err)
 		retryTopic := topic.GenerateRetryTopic(ConsumerGroup("group"))
-		assert.Equal(t, "my-topic"+topicSeparator+"group"+retrySuffix, string(retryTopic))
+		assert.Equal(t, "my-topic"+topicSeparator+"group"+topicSeparator+retrySuffix, string(retryTopic))
 	})
 }
 


### PR DESCRIPTION
Since not all consumer of this library will use AutoTopicCreation flag in the event queue system, this solution here is to allow retry topic creation when we subscribe to a topic. It dynamically creates the topic and handles topics that already exists.