### PR TITLE
feat: Add RequestIdHook that adds the RequestId from the context to the logger fields

### DIFF
--- a/logrusx/hooks.go
+++ b/logrusx/hooks.go
@@ -1,0 +1,41 @@
+package logrusx
+
+import "github.com/sirupsen/logrus"
+
+type requestIdHook struct {
+	rIdCtxKey   interface{}
+	rIdFieldKey string
+}
+
+var _ logrus.Hook = (*requestIdHook)(nil)
+
+func NewRequestIdHook(requestIdContextKey interface{}, requestIdFieldKey string) *requestIdHook {
+	return &requestIdHook{
+		rIdCtxKey:   requestIdContextKey,
+		rIdFieldKey: requestIdFieldKey,
+	}
+}
+
+func (irh *requestIdHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (rih *requestIdHook) Fire(entry *logrus.Entry) (outErr error) {
+	defer func() {
+		// Nullify panic to prevent having this hook break a request
+		if rec := recover(); rec != nil {
+			outErr = nil
+		}
+	}()
+	if entry == nil || entry.Context == nil {
+		return nil
+	}
+	requestId := entry.Context.Value(rih.rIdCtxKey)
+	if requestId == nil {
+		return nil
+	} else {
+		entry.Data[rih.rIdFieldKey] = requestId
+	}
+
+	return nil
+}

--- a/logrusx/hooks.go
+++ b/logrusx/hooks.go
@@ -20,14 +20,12 @@ func (irh *requestIdHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-func (rih *requestIdHook) Fire(entry *logrus.Entry) (outErr error) {
+func (rih *requestIdHook) Fire(entry *logrus.Entry) error {
 	defer func() {
 		// Nullify panic to prevent having this hook break a request
-		if rec := recover(); rec != nil {
-			outErr = nil
-		}
+		recover()
 	}()
-	if entry == nil || entry.Context == nil {
+	if entry == nil || entry.Context == nil || entry.Data == nil {
 		return nil
 	}
 	requestId := entry.Context.Value(rih.rIdCtxKey)

--- a/logrusx/hooks_test.go
+++ b/logrusx/hooks_test.go
@@ -1,0 +1,64 @@
+package logrusx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestKeyType string
+
+var testKey TestKeyType
+
+func TestFire(t *testing.T) {
+	t.Run("should update entry data with requestId", func(t *testing.T) {
+		e := logrus.Entry{}
+		e.Data = make(logrus.Fields, 6)
+		e.Context = context.WithValue(context.Background(), testKey, "rid")
+		assert.Nil(t, e.Data["RequestId"])
+		err := NewRequestIdHook(testKey, "RequestId").Fire(&e)
+		assert.NoError(t, err)
+		assert.Equal(t, "rid", e.Data["RequestId"])
+	})
+	t.Run("should do nothing on empty context", func(t *testing.T) {
+		e := logrus.Entry{}
+		e.Data = make(logrus.Fields, 6)
+		e.Context = context.Background()
+		assert.Nil(t, e.Data["RequestId"])
+		err := NewRequestIdHook(testKey, "RequestId").Fire(&e)
+		assert.NoError(t, err)
+		assert.Nil(t, e.Data["RequestId"])
+	})
+	t.Run("should do nothing on nil Context", func(t *testing.T) {
+		e := logrus.Entry{}
+		e.Data = make(logrus.Fields, 6)
+		e.Context = nil
+		assert.Nil(t, e.Data["RequestId"])
+		err := NewRequestIdHook(testKey, "RequestId").Fire(&e)
+		assert.NoError(t, err)
+		assert.Nil(t, e.Data["RequestId"])
+	})
+	t.Run("should do nothing on nil Data", func(t *testing.T) {
+		e := logrus.Entry{}
+		e.Data = nil
+		e.Context = context.WithValue(context.Background(), testKey, "rid")
+		assert.Nil(t, e.Data["RequestId"])
+		err := NewRequestIdHook(testKey, "RequestId").Fire(&e)
+		assert.NoError(t, err)
+		assert.Nil(t, e.Data["RequestId"])
+	})
+
+	t.Run("should do nothing on nil Entry", func(t *testing.T) {
+		err := NewRequestIdHook(testKey, "RequestId").Fire(nil)
+		assert.NoError(t, err)
+	})
+}
+
+func TestLevels(t *testing.T) {
+	t.Run("shoul return all levels", func(t *testing.T) {
+		levels := NewRequestIdHook(testKey, "RequestId").Levels()
+		assert.Equal(t, logrus.AllLevels, levels)
+	})
+}


### PR DESCRIPTION
Add a hook implementation that retrieve the RequestId from the context and puts it in the fields of the Logger. The hook is made to never throw an error to not break logging.