### PR TITLE
feat: Add httpx x-clinia-healthy constants and functions

### DIFF
--- a/httpx/header.go
+++ b/httpx/header.go
@@ -1,0 +1,29 @@
+package httpx
+
+import (
+	"net/http"
+
+	"github.com/clinia/x/errorx"
+)
+
+const (
+	CliniaHealthyHeaderKey = "X-Clinia-Healthy"
+	CliniaHealthyValue     = "true"
+	CliniaUnHeahlthyValue  = "false"
+)
+
+func SetCliniaHealthyHeader(r *http.Request) error {
+	if r == nil {
+		return errorx.InternalErrorf("request can not be nil")
+	}
+	r.Header.Add(CliniaHealthyHeaderKey, CliniaHealthyValue)
+	return nil
+}
+
+func SetCliniaUnHealthyHeader(r *http.Request) error {
+	if r == nil {
+		return errorx.InternalErrorf("request can not be nil")
+	}
+	r.Header.Add(CliniaHealthyHeaderKey, CliniaUnHeahlthyValue)
+	return nil
+}

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -9,7 +9,7 @@ import (
 const (
 	CliniaHealthyHeaderKey = "X-Clinia-Healthy"
 	CliniaHealthyValue     = "true"
-	CliniaUnHeahlthyValue  = "false"
+	CliniaUnHealthyValue   = "false"
 )
 
 func SetCliniaHealthyHeader(r *http.Request) error {
@@ -24,6 +24,6 @@ func SetCliniaUnHealthyHeader(r *http.Request) error {
 	if r == nil {
 		return errorx.InternalErrorf("request can not be nil")
 	}
-	r.Header.Add(CliniaHealthyHeaderKey, CliniaUnHeahlthyValue)
+	r.Header.Add(CliniaHealthyHeaderKey, CliniaUnHealthyValue)
 	return nil
 }

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -1,0 +1,34 @@
+package httpx
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetCliniaHealthyHeader(t *testing.T) {
+	t.Run("should panic on nil request", func(t *testing.T) {
+		assert.Error(t, SetCliniaHealthyHeader(nil))
+	})
+	t.Run("should add the clinia healthy header as being healthy", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://any.test/any", nil)
+		SetCliniaHealthyHeader(req)
+		h, ok := req.Header[CliniaHealthyHeaderKey]
+		assert.True(t, ok)
+		assert.Contains(t, h, CliniaHealthyValue)
+	})
+}
+
+func TestSetCliniaUnHealthyHeader(t *testing.T) {
+	t.Run("should panic on nil request", func(t *testing.T) {
+		assert.Error(t, SetCliniaUnHealthyHeader(nil))
+	})
+	t.Run("should add the clinia healthy header as being unhealthy", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://any.test/any", nil)
+		SetCliniaUnHealthyHeader(req)
+		h, ok := req.Header[CliniaHealthyHeaderKey]
+		assert.True(t, ok)
+		assert.Contains(t, h, CliniaUnHeahlthyValue)
+	})
+}

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -29,6 +29,6 @@ func TestSetCliniaUnHealthyHeader(t *testing.T) {
 		SetCliniaUnHealthyHeader(req)
 		h, ok := req.Header[CliniaHealthyHeaderKey]
 		assert.True(t, ok)
-		assert.Contains(t, h, CliniaUnHeahlthyValue)
+		assert.Contains(t, h, CliniaUnHealthyValue)
 	})
 }


### PR DESCRIPTION
Add `x-clinia-healthy` header information and function to help use it within `x`