### PR TITLE
fix: Helper function in httpx should update ResponseWriter instead of Request

### DIFF
--- a/httpx/header.go
+++ b/httpx/header.go
@@ -22,7 +22,7 @@ func SetCliniaHealthyHeader(w http.ResponseWriter) error {
 
 func SetCliniaUnHealthyHeader(w http.ResponseWriter) error {
 	if w == nil {
-		return errorx.InternalErrorf("response writer can not be nil")
+		return errorx.InternalErrorf("response writer cannot be nil")
 	}
 	w.Header().Add(CliniaHealthyHeaderKey, CliniaUnHealthyValue)
 	return nil

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -12,18 +12,18 @@ const (
 	CliniaUnHealthyValue   = "false"
 )
 
-func SetCliniaHealthyHeader(r *http.Request) error {
-	if r == nil {
-		return errorx.InternalErrorf("request can not be nil")
+func SetCliniaHealthyHeader(w http.ResponseWriter) error {
+	if w == nil {
+		return errorx.InternalErrorf("resposne writer can not be nil")
 	}
-	r.Header.Add(CliniaHealthyHeaderKey, CliniaHealthyValue)
+	w.Header().Add(CliniaHealthyHeaderKey, CliniaHealthyValue)
 	return nil
 }
 
-func SetCliniaUnHealthyHeader(r *http.Request) error {
-	if r == nil {
-		return errorx.InternalErrorf("request can not be nil")
+func SetCliniaUnHealthyHeader(w http.ResponseWriter) error {
+	if w == nil {
+		return errorx.InternalErrorf("response writer can not be nil")
 	}
-	r.Header.Add(CliniaHealthyHeaderKey, CliniaUnHealthyValue)
+	w.Header().Add(CliniaHealthyHeaderKey, CliniaUnHealthyValue)
 	return nil
 }

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -14,7 +14,7 @@ const (
 
 func SetCliniaHealthyHeader(w http.ResponseWriter) error {
 	if w == nil {
-		return errorx.InternalErrorf("resposne writer can not be nil")
+		return errorx.InternalErrorf("response writer cannot be nil")
 	}
 	w.Header().Add(CliniaHealthyHeaderKey, CliniaHealthyValue)
 	return nil

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -12,10 +12,9 @@ func TestSetCliniaHealthyHeader(t *testing.T) {
 		assert.Error(t, SetCliniaHealthyHeader(nil))
 	})
 	t.Run("should add the clinia healthy header as being healthy", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "http://any.test/any", nil)
-		SetCliniaHealthyHeader(req)
-		h, ok := req.Header[CliniaHealthyHeaderKey]
-		assert.True(t, ok)
+		w := httptest.NewRecorder()
+		SetCliniaHealthyHeader(w)
+		h := w.Header().Get(CliniaHealthyHeaderKey)
 		assert.Contains(t, h, CliniaHealthyValue)
 	})
 }
@@ -25,10 +24,9 @@ func TestSetCliniaUnHealthyHeader(t *testing.T) {
 		assert.Error(t, SetCliniaUnHealthyHeader(nil))
 	})
 	t.Run("should add the clinia healthy header as being unhealthy", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "http://any.test/any", nil)
-		SetCliniaUnHealthyHeader(req)
-		h, ok := req.Header[CliniaHealthyHeaderKey]
-		assert.True(t, ok)
+		w := httptest.NewRecorder()
+		SetCliniaUnHealthyHeader(w)
+		h := w.Header().Get(CliniaHealthyHeaderKey)
 		assert.Contains(t, h, CliniaUnHealthyValue)
 	})
 }


### PR DESCRIPTION
Fix of the helper function to updater header on the response we are writing instead of the request we are receiving.