### PR TITLE
feat: [ENG-1726] Add the configuration and logic to use manual commit instead of auto-commit

### DIFF
--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -17,15 +17,15 @@ jobs:
           go-version: "^1.21.1"
       - run: cat .env >> $GITHUB_ENV || true
       - name: Setup Kafka
-        run: docker compose -f docker-compose.kafka.kgox.yml up -d --wait
-      - run: go run github.com/ThreeDotsLabs/wait-for@latest localhost:9091 localhost:9092 localhost:9093 localhost:9094 localhost:9095
+        run: docker compose -f docker-compose.ci.kgox.yml up -d --wait
+      - run: go run github.com/ThreeDotsLabs/wait-for@latest localhost:19092 localhost:29092 localhost:39092
       - run: make test_kafka
         env:
-          KAFKA: localhost:9091,localhost:9092,localhost:9093,localhost:9094,localhost:9095
+          KAFKA: localhost:19092,localhost:29092,localhost:39092
         timeout-minutes: 30
       - run: make test_kafka_race
         env:
-          KAFKA: localhost:9091,localhost:9092,localhost:9093,localhost:9094,localhost:9095
+          KAFKA: localhost:19092,localhost:29092,localhost:39092
       - name: Tear down services
         if: always()
-        run: docker compose -f docker-compose.kgox.yml down -v
+        run: docker compose -f docker-compose.ci.kgox.yml down -v

--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -19,13 +19,25 @@ jobs:
       - name: Setup Kafka
         run: docker compose -f docker-compose.ci.kgox.yml up -d --wait
       - run: go run github.com/ThreeDotsLabs/wait-for@latest localhost:19092 localhost:29092 localhost:39092
-      - run: make test_kafka
+      - name: Test Kafka
+        uses: nick-fields/retry@v3.0.0
         env:
           KAFKA: localhost:19092,localhost:29092,localhost:39092
-        timeout-minutes: 30
-      - run: make test_kafka_race
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command: |
+            make test_kafka
+
+      - name: Test Kafka Race
+        uses: nick-fields/retry@v3.0.0
         env:
           KAFKA: localhost:19092,localhost:29092,localhost:39092
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command: |
+            make test_kafka_race
       - name: Tear down services
         if: always()
         run: docker compose -f docker-compose.ci.kgox.yml down -v

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -515,6 +515,8 @@ func (p *Provider) PubSubConfig() *pubsubx.Config {
 			Enabled:   p.BoolF("pubsub.poisonQueue.enabled", false),
 			TopicName: p.StringF("pubsub.poisonQueue.topicName", "poison-queue"),
 		},
+		DisableAutoCommit:    p.BoolF("pubsub.disableAutoCommit", false),
+		BlockRebalanceOnPoll: p.BoolF("pubsub.blockRebalanceOnPoll", false),
 	}
 }
 

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -515,7 +515,7 @@ func (p *Provider) PubSubConfig() *pubsubx.Config {
 			Enabled:   p.BoolF("pubsub.poisonQueue.enabled", false),
 			TopicName: p.StringF("pubsub.poisonQueue.topicName", "poison-queue"),
 		},
-		DisableAutoCommit: p.BoolF("pubsub.disableAutoCommit", false),
+		EnableAutoCommit: p.BoolF("pubsub.enableAutoCommit", true),
 	}
 }
 

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -515,8 +515,7 @@ func (p *Provider) PubSubConfig() *pubsubx.Config {
 			Enabled:   p.BoolF("pubsub.poisonQueue.enabled", false),
 			TopicName: p.StringF("pubsub.poisonQueue.topicName", "poison-queue"),
 		},
-		DisableAutoCommit:    p.BoolF("pubsub.disableAutoCommit", false),
-		BlockRebalanceOnPoll: p.BoolF("pubsub.blockRebalanceOnPoll", false),
+		DisableAutoCommit: p.BoolF("pubsub.disableAutoCommit", false),
 	}
 }
 

--- a/docker-compose.ci.kgox.yml
+++ b/docker-compose.ci.kgox.yml
@@ -1,0 +1,76 @@
+services:
+  redpanda:
+    profiles:
+      - prevent-default-start
+
+  redpanda-0:
+    image: redpandadata/redpanda:v24.2.5
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda-0:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://redpanda-0:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr redpanda-0:33145
+      - --advertise-rpc-addr redpanda-0:33145
+      - --smp 1
+      - --memory 1G
+      - --mode dev-container
+      - --default-log-level=debug
+      - --set redpanda.auto_create_topics_enabled=false
+    ports:
+      - 18081:18081
+      - 18082:18082
+      - 19092:19092
+      - 19644:9644
+
+  redpanda-1:
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:29092
+      - --advertise-kafka-addr internal://redpanda-1:9092,external://localhost:29092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:28082
+      - --advertise-pandaproxy-addr internal://redpanda-1:8082,external://localhost:28082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:28081
+      - --rpc-addr redpanda-1:33145
+      - --advertise-rpc-addr redpanda-1:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+      - --seeds redpanda-0:33145
+    image: redpandadata/redpanda:v24.2.5
+    container_name: redpanda-1
+    ports:
+      - 28081:28081
+      - 28082:28082
+      - 29092:29092
+      - 29644:9644
+    depends_on:
+      - redpanda-0
+  redpanda-2:
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:39092
+      - --advertise-kafka-addr internal://redpanda-2:9092,external://localhost:39092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:38082
+      - --advertise-pandaproxy-addr internal://redpanda-2:8082,external://localhost:38082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:38081
+      - --rpc-addr redpanda-2:33145
+      - --advertise-rpc-addr redpanda-2:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+      - --seeds redpanda-0:33145
+    image: redpandadata/redpanda:v24.2.5
+    container_name: redpanda-2
+    ports:
+      - 38081:38081
+      - 38082:38082
+      - 39092:39092
+      - 39644:9644
+    depends_on:
+      - redpanda-0

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.30.0
 	go.opentelemetry.io/otel/trace v1.30.0
 	go.opentelemetry.io/proto/otlp v1.0.0
+	golang.org/x/sync v0.7.0
 	google.golang.org/grpc v1.66.0
 	google.golang.org/protobuf v1.34.1
 )

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -13,12 +13,12 @@ import (
 )
 
 type Config struct {
-	PoisonQueue       PoisonQueueConfig `json:"poisonQueue"`
-	Scope             string            `json:"scope"`
-	Provider          string            `json:"provider"`
-	Providers         ProvidersConfig   `json:"providers"`
-	TopicRetry        bool              `json:"topicRetry"`
-	DisableAutoCommit bool              `json:"disableAutoCommit"`
+	PoisonQueue      PoisonQueueConfig `json:"poisonQueue"`
+	Scope            string            `json:"scope"`
+	Provider         string            `json:"provider"`
+	Providers        ProvidersConfig   `json:"providers"`
+	TopicRetry       bool              `json:"topicRetry"`
+	EnableAutoCommit bool              `json:"enableAutoCommit"`
 }
 
 type ProvidersConfig struct {

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -101,13 +101,17 @@ type SubscriberOptions struct {
 	MaxTopicRetryCount uint16
 	// Allows the handler to run each topic handling in parallel
 	EnableAsyncExecution bool
+	// Define the number of maximum topic handler that can run in parallel
+	// on record processing
+	MaxParallelAsyncExecution int16
 }
 
 func NewDefaultSubscriberOptions() *SubscriberOptions {
 	return &SubscriberOptions{
-		MaxBatchSize:         100,
-		MaxTopicRetryCount:   3,
-		EnableAsyncExecution: false,
+		MaxBatchSize:              100,
+		MaxTopicRetryCount:        3,
+		EnableAsyncExecution:      false,
+		MaxParallelAsyncExecution: -1,
 	}
 }
 
@@ -140,6 +144,12 @@ func WithMaxTopicRetryCount(maxTopicRetryCount int) SubscriberOption {
 func WithAsyncExecution() SubscriberOption {
 	return func(o *SubscriberOptions) {
 		o.EnableAsyncExecution = true
+	}
+}
+
+func WithMaxParalleAsyncExecution(max int16) SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.MaxParallelAsyncExecution = max
 	}
 }
 

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -13,13 +13,12 @@ import (
 )
 
 type Config struct {
-	PoisonQueue          PoisonQueueConfig `json:"poisonQueue"`
-	Scope                string            `json:"scope"`
-	Provider             string            `json:"provider"`
-	Providers            ProvidersConfig   `json:"providers"`
-	TopicRetry           bool              `json:"topicRetry"`
-	DisableAutoCommit    bool              `json:"disableAutoCommit"`
-	BlockRebalanceOnPoll bool              `json:"blockRebalanceOnPoll"`
+	PoisonQueue       PoisonQueueConfig `json:"poisonQueue"`
+	Scope             string            `json:"scope"`
+	Provider          string            `json:"provider"`
+	Providers         ProvidersConfig   `json:"providers"`
+	TopicRetry        bool              `json:"topicRetry"`
+	DisableAutoCommit bool              `json:"disableAutoCommit"`
 }
 
 type ProvidersConfig struct {

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -149,7 +149,11 @@ func WithAsyncExecution() SubscriberOption {
 
 func WithMaxParalleAsyncExecution(max int16) SubscriberOption {
 	return func(o *SubscriberOptions) {
-		o.MaxParallelAsyncExecution = max
+		if o.MaxParallelAsyncExecution <= 0 {
+			o.MaxParallelAsyncExecution = -1
+		} else {
+			o.MaxParallelAsyncExecution = max
+		}
 	}
 }
 

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -99,12 +99,15 @@ type SubscriberOptions struct {
 	// MaxTopicRetryCount indicate how many time we allow to push to
 	// the retry topic before considering a retryable error non retryable
 	MaxTopicRetryCount uint16
+	// Allows the handler to run each topic handling in parallel
+	EnableAsyncExecution bool
 }
 
 func NewDefaultSubscriberOptions() *SubscriberOptions {
 	return &SubscriberOptions{
-		MaxBatchSize:       100,
-		MaxTopicRetryCount: 3,
+		MaxBatchSize:         100,
+		MaxTopicRetryCount:   3,
+		EnableAsyncExecution: false,
 	}
 }
 
@@ -131,6 +134,12 @@ func WithMaxTopicRetryCount(maxTopicRetryCount int) SubscriberOption {
 			//#nosec G115 -- Remove once https://github.com/securego/gosec/issues/1187 is solved
 			o.MaxTopicRetryCount = uint16(maxTopicRetryCount)
 		}
+	}
+}
+
+func WithAsyncExecution() SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.EnableAsyncExecution = true
 	}
 }
 

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -13,11 +13,13 @@ import (
 )
 
 type Config struct {
-	PoisonQueue PoisonQueueConfig `json:"poisonQueue"`
-	Scope       string            `json:"scope"`
-	Provider    string            `json:"provider"`
-	Providers   ProvidersConfig   `json:"providers"`
-	TopicRetry  bool              `json:"topicRetry"`
+	PoisonQueue          PoisonQueueConfig `json:"poisonQueue"`
+	Scope                string            `json:"scope"`
+	Provider             string            `json:"provider"`
+	Providers            ProvidersConfig   `json:"providers"`
+	TopicRetry           bool              `json:"topicRetry"`
+	DisableAutoCommit    bool              `json:"disableAutoCommit"`
+	BlockRebalanceOnPoll bool              `json:"blockRebalanceOnPoll"`
 }
 
 type ProvidersConfig struct {

--- a/pubsubx/config.schema.json
+++ b/pubsubx/config.schema.json
@@ -84,11 +84,6 @@
       "type": "boolean",
       "description": "Disable auto-commit logic on records polling and use manual commit instead",
       "default": false
-    },
-    "blockRebalanceOnPoll": {
-      "type": "boolean",
-      "description": "Block rebalance on poll and enables it between polling, if record processing is too slow, the pubsub connection might timeout. This config is only used if manual commit is enabled",
-      "default": false
     }
   }
 }

--- a/pubsubx/config.schema.json
+++ b/pubsubx/config.schema.json
@@ -79,6 +79,16 @@
       "type": "boolean",
       "description": "Enable the retry mechanism with pubsub topic",
       "default": false
+    },
+    "disableAutoCommit": {
+      "type": "boolean",
+      "description": "Disable auto-commit logic on records polling and use manual commit instead",
+      "default": false
+    },
+    "blockRebalanceOnPoll": {
+      "type": "boolean",
+      "description": "Block rebalance on poll and enables it between polling, if record processing is too slow, the pubsub connection might timeout. This config is only used if manual commit is enabled",
+      "default": false
     }
   }
 }

--- a/pubsubx/config.schema.json
+++ b/pubsubx/config.schema.json
@@ -80,10 +80,10 @@
       "description": "Enable the retry mechanism with pubsub topic",
       "default": false
     },
-    "disableAutoCommit": {
+    "enableAutoCommit": {
       "type": "boolean",
-      "description": "Disable auto-commit logic on records polling and use manual commit instead",
-      "default": false
+      "description": "Enable auto-commit logic on records polling",
+      "default": true
     }
   }
 }

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -138,11 +138,6 @@ func (c *consumer) bootstrapClient(ctx context.Context) error {
 		)
 		// TODO: Add manual handling of the rebalancing while poling, currently we just assume that we might
 		// double process some records if it happens
-		if c.conf.BlockRebalanceOnPoll {
-			kopts = append(kopts,
-				kgo.BlockRebalanceOnPoll(),
-			)
-		}
 	}
 
 	client, err := kgo.NewClient(kopts...)

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -290,6 +290,7 @@ func (c *consumer) start(ctx context.Context) {
 			return
 		}
 		var wg errgroup.Group
+		wg.SetLimit(int(c.opts.MaxParallelAsyncExecution))
 		fetches.EachTopic(func(tp kgo.FetchTopic) {
 			switch {
 			case c.opts.EnableAsyncExecution:

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -26,7 +26,7 @@ type consumer struct {
 	group        messagex.ConsumerGroup
 	topics       []messagex.Topic
 	opts         *pubsubx.SubscriberOptions
-	handlers     pubsubx.Handlers
+	handlers     map[messagex.Topic]handlerExecutor
 	kotelService *kotel.Kotel
 	erh          *eventRetryHandler
 	pqh          PoisonQueueHandler
@@ -35,6 +35,32 @@ type consumer struct {
 	cancel context.CancelFunc
 	closed bool
 	wg     sync.WaitGroup
+}
+
+// TODO: Add the ability to handle repartition and cancel specific topic handling if the parition is revoked
+// TODO: Add gauge metric to record the current count of records that are being processed
+// TODO: Add a histogram metric to record the latency of the handler
+type handlerExecutor struct {
+	l *logrusx.Logger
+	h pubsubx.Handler
+	t messagex.Topic
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (he *handlerExecutor) handle(ctx context.Context, msgs []*messagex.Message) (outErrs []error, outErr error) {
+	he.ctx, he.cancel = context.WithCancel(ctx)
+	defer func() {
+		if r := recover(); r != nil {
+			outErr = errorx.InternalErrorf("panic while handling messages")
+			stackTrace := tracex.GetStackTrace()
+			he.l.WithContext(ctx).WithFields(logrusx.NewLogFields(semconv.ExceptionStacktrace(stackTrace))).Errorf("panic while handling messages")
+		}
+		he.cancel()
+		he.ctx, he.cancel = nil, nil
+	}()
+	return he.h(ctx, msgs)
 }
 
 var _ pubsubx.Subscriber = (*consumer)(nil)
@@ -106,6 +132,19 @@ func (c *consumer) bootstrapClient(ctx context.Context) error {
 		kopts = append(kopts, kgo.WithHooks(c.kotelService.Hooks()...))
 	}
 
+	if c.conf.DisableAutoCommit {
+		kopts = append(kopts,
+			kgo.DisableAutoCommit(),
+		)
+		// TODO: Add manual handling of the rebalancing while poling, currently we just assume that we might
+		// double process some records if it happens
+		if c.conf.BlockRebalanceOnPoll {
+			kopts = append(kopts,
+				kgo.BlockRebalanceOnPoll(),
+			)
+		}
+	}
+
 	client, err := kgo.NewClient(kopts...)
 	if err != nil {
 		return err
@@ -140,11 +179,79 @@ func (c *consumer) Close() error {
 	return nil
 }
 
-func (c *consumer) start(ctx context.Context) {
+func (c *consumer) convertRecordsToMessages(rs []*kgo.Record) []*messagex.Message {
+	// TODO: Handle the records that can't be Unmarhsal, now they are dropped and lost
+	msgs := make([]*messagex.Message, 0, len(rs))
+	for _, r := range rs {
+		m, err := defaultMarshaler.Unmarshal(r)
+		if err != nil {
+			c.l.WithError(err).Errorf("failed to unmarshal message: %v", err)
+			continue
+		}
+
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
+func (c *consumer) handleTopic(ctx context.Context, tp kgo.FetchTopic) error {
+	// Use base name to handle the retry topics under the same topic handler
+	topic := messagex.BaseTopicFromName(tp.Topic)
+	l := c.l.WithContext(ctx).WithFields(
+		logrusx.NewLogFields(c.attributes(&topic)...),
+	)
+	ctx = context.WithValue(ctx, ctxLoggerKey, l)
+
+	// We do not protect the read to handlers here since we cannot get to a point where the handlers are reset and we are still in this consuming loop
+	topicHandler, ok := c.handlers[topic]
+	if !ok {
+		l.Errorf("no handler for topic")
+		return errorx.InternalErrorf("no handler for topic")
+	}
+	msgs := c.convertRecordsToMessages(tp.Records())
+
 	bc := backoff.NewExponentialBackOff()
 	bc.MaxElapsedTime = maxElapsedTime
 	bc.MaxInterval = maxRetryInterval
+	retries := 0
+	err := backoff.Retry(func() error {
+		errs, err := topicHandler.handle(ctx, msgs)
+		if err != nil {
+			l.WithError(err).Errorf("error while handling messages")
 
+			if err == pubsubx.AbortSubscribeError() {
+				return backoff.Permanent(err)
+			}
+
+			retries++
+			if retries > maxRetryCount {
+				// In this case, we should abort the subscription as this is most likely a critical error
+				return backoff.Permanent(pubsubx.AbortSubscribeError())
+			}
+
+			return err
+		}
+
+		if len(errs) > 0 {
+			allErrs := errors.Join(errs...)
+			if allErrs != nil {
+				l.WithError(allErrs).Errorf("errors while handling messages")
+			}
+			c.handleRemoteRetryLogic(ctx, topic, errs, msgs)
+		}
+
+		return nil
+	}, bc)
+
+	if err == pubsubx.AbortSubscribeError() {
+		c.handleRemoteRetryLogic(ctx, topic, []error{errorx.NewRetryableError(err)}, msgs)
+	}
+
+	return err
+}
+
+func (c *consumer) start(ctx context.Context) {
+	l := c.l.WithContext(ctx)
 	for {
 		select {
 		case <-ctx.Done():
@@ -152,106 +259,57 @@ func (c *consumer) start(ctx context.Context) {
 		default:
 		}
 
+		// Sync task that hang until it receive at least one record
+		// When records are pulled, metadata is also updated within the client
 		fetches := c.cl.PollRecords(ctx, int(c.opts.MaxBatchSize))
 		if errs := fetches.Errors(); len(errs) > 0 {
 			// All errors are retried internally when fetching, but non-retriable errors are
 			// returned from polls so that users can notice and take action.
 			// TODO: Handle errors
 			// If its a context canceled error, we should return
-			l := c.l.WithContext(ctx).WithFields(
+			l := c.l.WithFields(
 				logrusx.NewLogFields(c.attributes(nil)...),
 			)
 			if lo.SomeBy(errs, func(err kgo.FetchError) bool { return errs[0].Err == context.Canceled }) {
-				l.Infof("context canceled, stopping consumer")
+				l.Warnf("context canceled, stopping consumer")
 				return
 			}
 
 			l.WithError(errors.Join(lo.Map(errs, func(err kgo.FetchError, i int) error { return err.Err })...)).Errorf("error while polling records, Stopping consumer")
 			return
 		}
-
+		wg := sync.WaitGroup{}
 		fetches.EachTopic(func(tp kgo.FetchTopic) {
-			// Use base name to handle the retry topics under the same topic handler
-			topic := messagex.BaseTopicFromName(tp.Topic)
-			l := c.l.WithContext(ctx).WithFields(
-				logrusx.NewLogFields(c.attributes(&topic)...),
-			)
-			ctx := context.WithValue(ctx, ctxLoggerKey, l)
-			records := tp.Records()
-			allMsgs := make([]*messagex.Message, 0, len(records))
-			for _, record := range records {
-				msg, err := defaultMarshaler.Unmarshal(record)
-				if err != nil {
-					l.Warnf("failed to unmarshal message: %v", err)
-					continue
-				}
-
-				allMsgs = append(allMsgs, msg)
-			}
-
-			// We do not protect the read to handlers here since we cannot get to a point where the handlers are reset and we are still in this consuming loop
-			topicHandler, ok := c.handlers[topic]
-			if !ok || topicHandler == nil {
-				l.Errorf("no handler for topic")
-				return
-			}
-			wrappedHandler := func(ctx context.Context, msgs []*messagex.Message) (outErrs []error, outErr error) {
-				defer func() {
-					if r := recover(); r != nil {
-						outErr = errorx.InternalErrorf("panic while handling messages")
-						stackTrace := tracex.GetStackTrace()
-						l.WithContext(ctx).WithFields(logrusx.NewLogFields(semconv.ExceptionStacktrace(stackTrace))).Errorf("panic while handling messages")
+			wg.Add(1)
+			defer wg.Done()
+			// TODO: Look into making this here a go-routine to allow parallel execution of all topics handled by this consumer
+			// WaitGroup is currently useless as the logic is running serially.
+			if err := c.handleTopic(ctx, tp); err != nil {
+				if err == pubsubx.AbortSubscribeError() {
+					l.Infof("aborting consumer")
+					c.mu.RLock()
+					defer c.mu.RUnlock()
+					// This is required since the context is cancelled by the backoff
+					if c.cancel != nil {
+						c.cancel()
+						l.WithError(err).Infof("cancelled consumer")
+					} else {
+						l.WithError(err).Warnf("abort requested but no cancel function found, this should not happen")
 					}
-				}()
-				return topicHandler(ctx, msgs)
-			}
-
-			bc.Reset()
-			retries := 0
-			err := backoff.Retry(func() error {
-				errs, err := wrappedHandler(ctx, allMsgs)
-				if err != nil {
-					if err == pubsubx.AbortSubscribeError() {
-						return backoff.Permanent(err)
-					}
-
-					l.WithError(err).Errorf("error while handling messages")
-
-					retries++
-					if retries > maxRetryCount {
-						// In this case, we should abort the subscription as this is most likely a critical error
-						return backoff.Permanent(pubsubx.AbortSubscribeError())
-					}
-
-					return err
+					return
 				}
-
-				if len(errs) > 0 {
-					allErrs := errors.Join(errs...)
-					if allErrs != nil {
-						l.WithError(allErrs).Errorf("errors while handling messages")
-					}
-					c.handleRemoteRetryLogic(ctx, topic, errs, allMsgs)
-				}
-
-				return nil
-			}, bc)
-
-			if err == pubsubx.AbortSubscribeError() {
-				l.Infof("aborting consumer")
-				c.mu.RLock()
-				defer c.mu.RUnlock()
-				c.handleRemoteRetryLogic(ctx, topic, []error{errorx.NewRetryableError(err)}, allMsgs)
-				// This is required since the context is cancelled by the backoff
-				if c.cancel != nil {
-					c.cancel()
-					l.Infof("cancelled consumer")
-				} else {
-					l.Warnf("abort requested but no cancel function found")
-				}
-				return
+				l.WithError(err).Warnf("unhandled error happened while handling topic : %s", tp.Topic)
 			}
 		})
+		wg.Wait()
+		if c.conf.DisableAutoCommit {
+			// If commiting the offsets fails, kill the loop by returning
+			if err := c.cl.CommitUncommittedOffsets(ctx); err != nil {
+				l.WithError(err).Errorf("failed to commit records")
+				return
+			}
+		}
+		c.cl.AllowRebalance()
 	}
 }
 
@@ -294,11 +352,18 @@ func (c *consumer) publishPoisonQueueMessages(ctx context.Context, topic message
 
 // Subscribe implements pubsubx.Subscriber.
 func (c *consumer) Subscribe(ctx context.Context, topicHandlers pubsubx.Handlers) error {
+	handlers := make(map[messagex.Topic]handlerExecutor)
 	for _, topic := range c.topics {
-		if handler, ok := topicHandlers[topic]; !ok {
+		handler, ok := topicHandlers[topic]
+		if !ok {
 			return errorx.FailedPreconditionErrorf("missing handler for topic %s", topic)
 		} else if handler == nil {
 			return errorx.FailedPreconditionErrorf("nil handler for topic %s", topic)
+		}
+		handlers[topic] = handlerExecutor{
+			t: topic,
+			h: handler,
+			l: c.l,
 		}
 	}
 
@@ -323,7 +388,7 @@ func (c *consumer) Subscribe(ctx context.Context, topicHandlers pubsubx.Handlers
 	}
 	ctx, cancel := context.WithCancel(ctx)
 
-	c.handlers = topicHandlers
+	c.handlers = handlers
 	c.cancel = cancel
 
 	c.wg.Add(1)

--- a/pubsubx/kgox/consumer_test.go
+++ b/pubsubx/kgox/consumer_test.go
@@ -198,9 +198,6 @@ func consumer_Subscribe_Handling_test(t *testing.T, eae bool) {
 		sendMessage(t, ctx, wClient, topics[0], expectedMsg2)
 		// This waits for the failed execution
 		wg.Wait()
-
-		// Add some sleep time to make sure the consumer has time to cancel it's execution
-		time.Sleep(2 * time.Second)
 		consumer.wg.Wait()
 
 		ctx = context.Background()

--- a/pubsubx/kgox/consumer_test.go
+++ b/pubsubx/kgox/consumer_test.go
@@ -523,7 +523,7 @@ func consumer_Subscribe_Concurrency_test(t *testing.T, eae bool) {
 		group, topics := getRandomGroupTopics(t, 3)
 		counter := make([]atomic.Int32, len(topics))
 		wClient := getWriteClient(t)
-		hs := make(pubsubx.Handlers)
+		hs := make(pubsubx.Handlers, len(topics))
 		for i, topic := range topics {
 			createTopic(t, config, topic)
 			hs[topic] = func(ctx context.Context, msgs []*messagex.Message) ([]error, error) {

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -60,8 +60,7 @@ func getPubsubConfig(t *testing.T, retry bool) *pubsubx.Config {
 			TopicName: "poison-queue",
 			Enabled:   false,
 		},
-		DisableAutoCommit:    true,
-		BlockRebalanceOnPoll: false,
+		DisableAutoCommit: true,
 	}
 }
 

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -60,7 +60,7 @@ func getPubsubConfig(t *testing.T, retry bool) *pubsubx.Config {
 			TopicName: "poison-queue",
 			Enabled:   false,
 		},
-		DisableAutoCommit: true,
+		EnableAutoCommit: false,
 	}
 }
 

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -60,6 +60,8 @@ func getPubsubConfig(t *testing.T, retry bool) *pubsubx.Config {
 			TopicName: "poison-queue",
 			Enabled:   false,
 		},
+		DisableAutoCommit:    true,
+		BlockRebalanceOnPoll: false,
 	}
 }
 


### PR DESCRIPTION
This is the first iteration of improvement for the manual commit logic for the consumer. The current implementation is trivial as it execute all the records the consumer received in the poll batch and then only commit all the record that were processed at the end. This allows to prevent issue such as : 

- Network failure while processing that prevent the record to actually be handled
- Node failure where the instance that was executing the logic simply fails and never reach completion

Current usage of the consumer is mostly only using a single partition, therefore the rebalancing while polling issue is not currently an issue. But to ensure better performance and reduce the possibility of processing multiple time a same event, we should look into a followup to allow async execution of the batch and to handle partition rebalancing.