### PR TITLE
fix: index name methods

### DIFF
--- a/elasticx/index_name.go
+++ b/elasticx/index_name.go
@@ -10,20 +10,20 @@ func NewIndexName(elements ...string) IndexName {
 	return IndexName(strings.Join(elements, pathSeparator))
 }
 
-func (i IndexName) elements() []string {
+func (i IndexName) Elements() []string {
 	return strings.Split(string(i), pathSeparator)
 }
 
 func (i IndexName) EngineName() string {
-	elems := i.elements()
+	elems := i.Elements()
 	if len(elems) < 2 {
 		return ""
 	}
-	return i.elements()[1]
+	return i.Elements()[1]
 }
 
 func (i IndexName) Name() string {
-	elems := i.elements()
+	elems := i.Elements()
 	if len(elems) < 3 {
 		return ""
 	}

--- a/elasticx/index_name.go
+++ b/elasticx/index_name.go
@@ -10,20 +10,24 @@ func NewIndexName(elements ...string) IndexName {
 	return IndexName(strings.Join(elements, pathSeparator))
 }
 
-func (i IndexName) Elements() []string {
+func (i IndexName) elements() []string {
 	return strings.Split(string(i), pathSeparator)
 }
 
 func (i IndexName) EngineName() string {
-	return i.Elements()[1]
+	elems := i.elements()
+	if len(elems) < 2 {
+		return ""
+	}
+	return i.elements()[1]
 }
 
 func (i IndexName) Name() string {
-	elems := i.Elements()
+	elems := i.elements()
 	if len(elems) < 3 {
 		return ""
 	}
-	return i.Elements()[2]
+	return strings.Join(elems[2:], pathSeparator)
 }
 
 func (i IndexName) String() string {

--- a/elasticx/index_name_test.go
+++ b/elasticx/index_name_test.go
@@ -11,4 +11,29 @@ func TestIndexName(t *testing.T) {
 		name := NewIndexName("a", "b", "c")
 		assert.Equal(t, "a~b~c", name.String())
 	})
+
+	t.Run("should return the engine name", func(t *testing.T) {
+		name := NewIndexName("a")
+		assert.Equal(t, "", name.EngineName())
+
+		name = NewIndexName("a", "b")
+		assert.Equal(t, "b", name.EngineName())
+
+		name = NewIndexName("a", "b", "c")
+		assert.Equal(t, "b", name.EngineName())
+	})
+
+	t.Run("should return the index name", func(t *testing.T) {
+		name := NewIndexName("a")
+		assert.Equal(t, "", name.Name())
+
+		name = NewIndexName("a", "b")
+		assert.Equal(t, "", name.Name())
+
+		name = NewIndexName("a", "b", "c")
+		assert.Equal(t, "c", name.Name())
+
+		name = NewIndexName("a", "b", "c", "d")
+		assert.Equal(t, "c~d", name.Name())
+	})
 }


### PR DESCRIPTION
This PR modifies the indexName methods to support index with more than 3 parts. 
For example, for the index `clinia-engines~atlas~source~1.resources.clinic` the name should be `source~1.resources.clinic` instead of only `source`