### PR TITLE
chore: [ENG-2062] kgox tests & reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test_kafka:
 
 .PHONY: test_kafka_race
 test_kafka_race:
-	go test ./pubsubx/kgox/... -short -race
+	go test -v ./pubsubx/kgox/... -short -race
 
 .PHONY: lint
 lint:

--- a/docker-compose.kgox.yml
+++ b/docker-compose.kgox.yml
@@ -4,7 +4,7 @@ services:
       - prevent-default-start
 
   redpanda-0:
-    image: oci.clinia.dev/rp/redpandadata/redpanda:v24.2.5
+    image: redpandadata/redpanda:v24.2.5
     command:
       - redpanda
       - start
@@ -42,7 +42,7 @@ services:
       - --smp 1
       - --default-log-level=info
       - --seeds redpanda-0:33145
-    image: oci.clinia.dev/rp/redpandadata/redpanda:v24.2.5
+    image: redpandadata/redpanda:v24.2.5
     container_name: redpanda-1
     ports:
       - 28081:28081
@@ -67,7 +67,7 @@ services:
       - --smp 1
       - --default-log-level=info
       - --seeds redpanda-0:33145
-    image: oci.clinia.dev/rp/redpandadata/redpanda:v24.2.5
+    image: redpandadata/redpanda:v24.2.5
     container_name: redpanda-2
     ports:
       - 38081:38081

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -109,14 +109,18 @@ type SubscriberOptions struct {
 	DialTimeout time.Duration
 	// Defaults to 60s. This should be big enough to allow enough time to process a batch.
 	RebalanceTimeout time.Duration
+	// Defaults to 1s. This setting is only relevant if the pubsub Config.EnableAutoCommit is set to false (manual commit).
+	// It dictates how long a call to Close() will wait for a commit that's in progress before closing the connection.
+	WaitForCommitOnCloseTimeout time.Duration
 }
 
 func NewDefaultSubscriberOptions() *SubscriberOptions {
 	return &SubscriberOptions{
-		MaxBatchSize:              100,
-		MaxTopicRetryCount:        3,
-		EnableAsyncExecution:      false,
-		MaxParallelAsyncExecution: -1,
+		MaxBatchSize:                100,
+		MaxTopicRetryCount:          3,
+		EnableAsyncExecution:        false,
+		MaxParallelAsyncExecution:   -1,
+		WaitForCommitOnCloseTimeout: 1 * time.Second,
 	}
 }
 
@@ -159,6 +163,24 @@ func WithMaxParalleAsyncExecution(max int16) SubscriberOption {
 		} else {
 			o.MaxParallelAsyncExecution = max
 		}
+	}
+}
+
+func WithDialTimeout(timeout time.Duration) SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.DialTimeout = timeout
+	}
+}
+
+func WithRebalanceTimeout(timeout time.Duration) SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.RebalanceTimeout = timeout
+	}
+}
+
+func WithWaitForCommitOnCloseTimeout(timeout time.Duration) SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.WaitForCommitOnCloseTimeout = timeout
 	}
 }
 

--- a/pubsubx/config.go
+++ b/pubsubx/config.go
@@ -109,18 +109,14 @@ type SubscriberOptions struct {
 	DialTimeout time.Duration
 	// Defaults to 60s. This should be big enough to allow enough time to process a batch.
 	RebalanceTimeout time.Duration
-	// Defaults to 1s. This setting is only relevant if the pubsub Config.EnableAutoCommit is set to false (manual commit).
-	// It dictates how long a call to Close() will wait for a commit that's in progress before closing the connection.
-	WaitForCommitOnCloseTimeout time.Duration
 }
 
 func NewDefaultSubscriberOptions() *SubscriberOptions {
 	return &SubscriberOptions{
-		MaxBatchSize:                100,
-		MaxTopicRetryCount:          3,
-		EnableAsyncExecution:        false,
-		MaxParallelAsyncExecution:   -1,
-		WaitForCommitOnCloseTimeout: 1 * time.Second,
+		MaxBatchSize:              100,
+		MaxTopicRetryCount:        3,
+		EnableAsyncExecution:      false,
+		MaxParallelAsyncExecution: -1,
 	}
 }
 
@@ -175,12 +171,6 @@ func WithDialTimeout(timeout time.Duration) SubscriberOption {
 func WithRebalanceTimeout(timeout time.Duration) SubscriberOption {
 	return func(o *SubscriberOptions) {
 		o.RebalanceTimeout = timeout
-	}
-}
-
-func WithWaitForCommitOnCloseTimeout(timeout time.Duration) SubscriberOption {
-	return func(o *SubscriberOptions) {
-		o.WaitForCommitOnCloseTimeout = timeout
 	}
 }
 

--- a/pubsubx/kgox/consumer_test.go
+++ b/pubsubx/kgox/consumer_test.go
@@ -233,22 +233,7 @@ func consumer_Subscribe_Handling_test(t *testing.T, eae bool) {
 		// This waits for the failed execution
 		wg.Wait()
 
-		// Here, even if the WaitForCommitOnCloseTimeout is set to a big value,
-		// we should return before that because the connection is closed
-		// Wrapping with a timeout to ensure the test doesn't hang if the above statement is not respected
-		consumer.opts.WaitForCommitOnCloseTimeout = 999 * time.Second
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		t.Cleanup(cancel)
-		done := make(chan struct{})
-		go func() {
-			consumer.Close()
-			close(done)
-		}()
-		select {
-		case <-ctx.Done():
-			t.Fatalf("timed out waiting for the consumer to close")
-		case <-done:
-		}
+		consumer.Close()
 
 		// We reenable the proxies to make sure we can consume again with the new consumer
 		enableProxies()
@@ -345,7 +330,7 @@ func consumer_Subscribe_Concurrency_test(t *testing.T, eae bool) {
 	l := Logger()
 	config := getPubsubConfig(t, false)
 	pqh := getPoisonQueueHandler(t, l, config)
-	opts := &pubsubx.SubscriberOptions{MaxBatchSize: 10, EnableAsyncExecution: eae, RebalanceTimeout: 1 * time.Second, DialTimeout: 1 * time.Second, WaitForCommitOnCloseTimeout: 1 * time.Second}
+	opts := &pubsubx.SubscriberOptions{MaxBatchSize: 10, EnableAsyncExecution: eae, RebalanceTimeout: 1 * time.Second, DialTimeout: 1 * time.Second}
 
 	getWriteClient := func(t *testing.T) *kgo.Client {
 		t.Helper()

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 	"github.com/clinia/x/logrusx"
 	"github.com/clinia/x/pubsubx"
 	"github.com/clinia/x/pubsubx/messagex"
@@ -22,6 +23,35 @@ const (
 	defaultExpectedReceiveTimeout   = 30 * time.Second
 	defaultExpectedNoReceiveTimeout = 5 * time.Second
 )
+
+type proxyFixture struct {
+	cl      *toxiproxy.Client
+	proxies []*toxiproxy.Proxy
+}
+
+func newProxyFixture(t *testing.T) *proxyFixture {
+	cl := toxiproxy.NewClient("localhost:8474")
+	proxies := []*toxiproxy.Proxy{}
+	for i := range 3 {
+		proxy, err := cl.Proxy(fmt.Sprintf("redpanda_%d", i))
+		require.NoError(t, err)
+		proxies = append(proxies, proxy)
+	}
+
+	return &proxyFixture{cl: cl, proxies: proxies}
+}
+
+func (f *proxyFixture) EnableAll() {
+	for _, p := range f.proxies {
+		p.Enable()
+	}
+}
+
+func (f *proxyFixture) DisableAll() {
+	for _, p := range f.proxies {
+		p.Disable()
+	}
+}
 
 func getRandomGroupTopics(t *testing.T, count int) (Group string, Topics []messagex.Topic) {
 	t.Helper()

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultExpectedReceiveTimeout   = 30 * time.Second
 	defaultExpectedNoReceiveTimeout = 5 * time.Second
+	defaultAssertTimeout            = 10 * time.Second
 )
 
 type proxyFixture struct {


### PR DESCRIPTION
Refactors a bit the current tests we have for `kgox`.
This also makes the `consumer.Close()` method a graceful stop that will wait until the current execution is finished before closing