### PR TITLE
feat: [ENG-2103] Add kgox logger

### DIFF
--- a/docker-compose.kgox.yml
+++ b/docker-compose.kgox.yml
@@ -83,8 +83,10 @@ services:
     network_mode: host
     volumes:
       - ./toxiproxy.json:/toxiconfig.json
+    ports:
+      - 8474:8474
   redpanda-console:
-    image: oci.clinia.dev/rp/redpandadata/console:v2.7.2
+    image: redpandadata/console:v2.7.2
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/docker-compose.kgox.yml
+++ b/docker-compose.kgox.yml
@@ -83,8 +83,6 @@ services:
     network_mode: host
     volumes:
       - ./toxiproxy.json:/toxiconfig.json
-    ports:
-      - 8474:8474
   redpanda-console:
     image: redpandadata/console:v2.7.2
     entrypoint: /bin/sh

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -123,6 +123,7 @@ func (c *consumer) bootstrapClient(ctx context.Context) error {
 		kgo.ConsumerGroup(c.group.ConsumerGroup(c.conf.Scope)),
 		kgo.SeedBrokers(c.conf.Providers.Kafka.Brokers...),
 		kgo.ConsumeTopics(scopedTopics...),
+		kgo.WithLogger(&pubsubLogger{l: c.l}),
 	}
 
 	if c.opts.DialTimeout > 0 {

--- a/pubsubx/kgox/consumer_test.go
+++ b/pubsubx/kgox/consumer_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 	"sync"
@@ -14,19 +13,12 @@ import (
 	"time"
 
 	"github.com/clinia/x/errorx"
-	"github.com/clinia/x/logrusx"
 	"github.com/clinia/x/pubsubx"
 	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
-
-func Logger() *logrusx.Logger {
-	l := logrusx.New("Clinia x", "testing")
-	l.Entry.Logger.SetOutput(io.Discard)
-	return l
-}
 
 func TestConsumer_Subscribe_Handling(t *testing.T) {
 	consumer_Subscribe_Handling_test(t, false)
@@ -37,7 +29,7 @@ func TestConsumer_Subscribe_Handling_async(t *testing.T) {
 }
 
 func consumer_Subscribe_Handling_test(t *testing.T, eae bool) {
-	l := Logger()
+	l := getLogger()
 	tf := newProxyFixture(t)
 	tf.EnableAll()
 	t.Cleanup(tf.EnableAll)
@@ -305,7 +297,7 @@ func TestConsumer_Subscribe_Concurrency_async(t *testing.T) {
 }
 
 func consumer_Subscribe_Concurrency_test(t *testing.T, eae bool) {
-	l := Logger()
+	l := getLogger()
 	tf := newProxyFixture(t)
 	tf.EnableAll()
 	t.Cleanup(tf.EnableAll)

--- a/pubsubx/kgox/event_retry_handler_test.go
+++ b/pubsubx/kgox/event_retry_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/clinia/x/logrusx"
 	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestGenerateRetryTopics(t *testing.T) {
-	l := logrusx.New("test", "")
+	l := getLogger()
 	config := getPubsubConfig(t, true)
 
 	t.Run("should create retry topic for the topic list", func(t *testing.T) {

--- a/pubsubx/kgox/poison_queue_handler_test.go
+++ b/pubsubx/kgox/poison_queue_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/clinia/x/logrusx"
 	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +16,7 @@ import (
 )
 
 func TestPublishMessagesToPoisonQueue(t *testing.T) {
-	l := logrusx.New("test", "")
-
+	l := getLogger()
 	t.Run("should not do anything if the messages list is empty", func(t *testing.T) {
 		config := getPubSubConfigWithCustomPoisonQueue(t, true, "pq-test-1")
 		pqTopic := messagex.TopicFromName(config.PoisonQueue.TopicName).TopicName(config.Scope)
@@ -390,7 +388,7 @@ func TestPublishMessagesToPoisonQueue(t *testing.T) {
 }
 
 func TestConsumeQueue(t *testing.T) {
-	l := logrusx.New("test", "v0")
+	l := getLogger()
 	t.Run("should consume queue up to the current event", func(t *testing.T) {
 		config := getPubSubConfigWithCustomPoisonQueue(t, true, "pq-test-consume-1")
 		pqTopic := messagex.TopicFromName(config.PoisonQueue.TopicName).TopicName(config.Scope)

--- a/pubsubx/kgox/publisher_test.go
+++ b/pubsubx/kgox/publisher_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/clinia/x/logrusx"
 	"github.com/clinia/x/pubsubx"
 	"github.com/clinia/x/pubsubx/messagex"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestPublisher(t *testing.T) {
-	l := logrusx.New("test", "")
+	l := getLogger()
 	config := getPubsubConfig(t, false)
 
 	receivedMessages := func(t *testing.T, group string, topic messagex.Topic) <-chan *messagex.Message {

--- a/pubsubx/kgox/pubsub.go
+++ b/pubsubx/kgox/pubsub.go
@@ -52,6 +52,7 @@ func NewPubSub(l *logrusx.Logger, config *pubsubx.Config, opts *pubsubx.PubSubOp
 
 	kopts := []kgo.Opt{
 		kgo.SeedBrokers(config.Providers.Kafka.Brokers...),
+		kgo.WithLogger(&pubsubLogger{l: l}),
 	}
 
 	// Setup kotel

--- a/pubsubx/kgox/pubsub_logger.go
+++ b/pubsubx/kgox/pubsub_logger.go
@@ -50,12 +50,14 @@ func (cl *pubsubLogger) Level() kgo.LogLevel {
 
 func (cl *pubsubLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 	fields := make(logrus.Fields)
+	// By design, the keyvals slice should always be a pair length as each key comes
+	// with a subsequent entry that is a val
 	if len(keyvals)%2 != 0 {
 		cl.l.Errorf("failed to evaluate keyvals : %v", keyvals)
 	} else {
 		for i := range keyvals {
 			if i%2 == 0 {
-				fields[keyvals[i].(string)] = keyvals[i+1]
+				fields["pubsub."+keyvals[i].(string)] = keyvals[i+1]
 			}
 		}
 	}

--- a/pubsubx/kgox/pubsub_logger.go
+++ b/pubsubx/kgox/pubsub_logger.go
@@ -59,5 +59,5 @@ func (cl *pubsubLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 			}
 		}
 	}
-	cl.l.WithFields(fields).Logf(kgoLogLevelToLogrusLogLevel(level), msg)
+	cl.l.WithFields(fields).Logf(kgoLogLevelToLogrusLogLevel(level), "%s", msg)
 }

--- a/pubsubx/kgox/pubsub_logger.go
+++ b/pubsubx/kgox/pubsub_logger.go
@@ -22,12 +22,13 @@ func kgoLogLevelToLogrusLogLevel(l kgo.LogLevel) logrus.Level {
 		return logrus.ErrorLevel
 	case kgo.LogLevelNone:
 		return logrus.PanicLevel
+	default:
+		return logrus.InfoLevel
 	}
-	return logrus.InfoLevel
 }
 
-func (cl *pubsubLogger) Level() kgo.LogLevel {
-	switch cl.l.Entry.Level {
+func logrusLogLevelToKgoLogLevel(l logrus.Level) kgo.LogLevel {
+	switch l {
 	case logrus.TraceLevel, logrus.DebugLevel:
 		return kgo.LogLevelDebug
 	case logrus.InfoLevel:
@@ -36,10 +37,15 @@ func (cl *pubsubLogger) Level() kgo.LogLevel {
 		return kgo.LogLevelWarn
 	case logrus.ErrorLevel:
 		return kgo.LogLevelError
-	case logrus.FatalLevel:
+	case logrus.FatalLevel, logrus.PanicLevel:
 		return kgo.LogLevelNone
+	default:
+		return kgo.LogLevelInfo
 	}
-	return kgo.LogLevelInfo
+}
+
+func (cl *pubsubLogger) Level() kgo.LogLevel {
+	return logrusLogLevelToKgoLogLevel(cl.l.Logrus().GetLevel())
 }
 
 func (cl *pubsubLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {

--- a/pubsubx/kgox/pubsub_logger.go
+++ b/pubsubx/kgox/pubsub_logger.go
@@ -1,0 +1,57 @@
+package kgox
+
+import (
+	"github.com/clinia/x/logrusx"
+	"github.com/sirupsen/logrus"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type pubsubLogger struct {
+	l *logrusx.Logger
+}
+
+func kgoLogLevelToLogrusLogLevel(l kgo.LogLevel) logrus.Level {
+	switch l {
+	case kgo.LogLevelDebug:
+		return logrus.DebugLevel
+	case kgo.LogLevelInfo:
+		return logrus.InfoLevel
+	case kgo.LogLevelWarn:
+		return logrus.WarnLevel
+	case kgo.LogLevelError:
+		return logrus.ErrorLevel
+	case kgo.LogLevelNone:
+		return logrus.PanicLevel
+	}
+	return logrus.InfoLevel
+}
+
+func (cl *pubsubLogger) Level() kgo.LogLevel {
+	switch cl.l.Entry.Level {
+	case logrus.TraceLevel, logrus.DebugLevel:
+		return kgo.LogLevelDebug
+	case logrus.InfoLevel:
+		return kgo.LogLevelInfo
+	case logrus.WarnLevel:
+		return kgo.LogLevelWarn
+	case logrus.ErrorLevel:
+		return kgo.LogLevelError
+	case logrus.FatalLevel:
+		return kgo.LogLevelNone
+	}
+	return kgo.LogLevelInfo
+}
+
+func (cl *pubsubLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
+	fields := make(logrus.Fields)
+	if len(keyvals)%2 != 0 {
+		cl.l.Errorf("failed to evaluate keyvals : %v", keyvals)
+	} else {
+		for i := range keyvals {
+			if i%2 == 0 {
+				fields[keyvals[i].(string)] = keyvals[i+1]
+			}
+		}
+	}
+	cl.l.WithFields(fields).Logf(kgoLogLevelToLogrusLogLevel(level), msg)
+}

--- a/pubsubx/kgox/pubsub_logger_test.go
+++ b/pubsubx/kgox/pubsub_logger_test.go
@@ -1,0 +1,35 @@
+package kgox
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestPubSubLogger(t *testing.T) {
+	t.Run("should return the proper log level", func(t *testing.T) {
+		value := []kgo.LogLevel{
+			kgo.LogLevelNone,
+			kgo.LogLevelDebug,
+			kgo.LogLevelInfo,
+			kgo.LogLevelWarn,
+			kgo.LogLevelError,
+			kgo.LogLevel(7), // Unknown Level
+		}
+		expected := []logrus.Level{
+			logrus.PanicLevel,
+			logrus.DebugLevel,
+			logrus.InfoLevel,
+			logrus.WarnLevel,
+			logrus.ErrorLevel,
+			logrus.InfoLevel,
+		}
+		require.Equal(t, len(value), len(expected))
+		for i := range value {
+			assert.Equal(t, expected[i], kgoLogLevelToLogrusLogLevel(value[i]))
+		}
+	})
+}

--- a/pubsubx/kgox/pubsub_logger_test.go
+++ b/pubsubx/kgox/pubsub_logger_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPubSubLogger(t *testing.T) {
-	t.Run("should return the proper log level", func(t *testing.T) {
+	t.Run("should return the proper log level from kgo", func(t *testing.T) {
 		value := []kgo.LogLevel{
 			kgo.LogLevelNone,
 			kgo.LogLevelDebug,
@@ -30,6 +30,33 @@ func TestPubSubLogger(t *testing.T) {
 		require.Equal(t, len(value), len(expected))
 		for i := range value {
 			assert.Equal(t, expected[i], kgoLogLevelToLogrusLogLevel(value[i]))
+		}
+	})
+
+	t.Run("should return the proper log level from logrus", func(t *testing.T) {
+		value := []logrus.Level{
+			logrus.FatalLevel,
+			logrus.PanicLevel,
+			logrus.TraceLevel,
+			logrus.DebugLevel,
+			logrus.InfoLevel,
+			logrus.WarnLevel,
+			logrus.ErrorLevel,
+			logrus.Level(10),
+		}
+		expected := []kgo.LogLevel{
+			kgo.LogLevelNone,
+			kgo.LogLevelNone,
+			kgo.LogLevelDebug,
+			kgo.LogLevelDebug,
+			kgo.LogLevelInfo,
+			kgo.LogLevelWarn,
+			kgo.LogLevelError,
+			kgo.LogLevelInfo,
+		}
+		require.Equal(t, len(value), len(expected))
+		for i := range value {
+			assert.Equal(t, expected[i], logrusLogLevelToKgoLogLevel(value[i]))
 		}
 	})
 }

--- a/pubsubx/kgox/pubsub_logger_test.go
+++ b/pubsubx/kgox/pubsub_logger_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-func TestPubSubLogger(t *testing.T) {
+func TestPubSubLoggerHelper(t *testing.T) {
 	t.Run("should return the proper log level from kgo", func(t *testing.T) {
 		value := []kgo.LogLevel{
 			kgo.LogLevelNone,
@@ -20,7 +21,7 @@ func TestPubSubLogger(t *testing.T) {
 			kgo.LogLevel(7), // Unknown Level
 		}
 		expected := []logrus.Level{
-			logrus.PanicLevel,
+			logrus.TraceLevel,
 			logrus.DebugLevel,
 			logrus.InfoLevel,
 			logrus.WarnLevel,
@@ -45,8 +46,8 @@ func TestPubSubLogger(t *testing.T) {
 			logrus.Level(10),
 		}
 		expected := []kgo.LogLevel{
-			kgo.LogLevelNone,
-			kgo.LogLevelNone,
+			kgo.LogLevelError,
+			kgo.LogLevelError,
 			kgo.LogLevelDebug,
 			kgo.LogLevelDebug,
 			kgo.LogLevelInfo,
@@ -58,5 +59,96 @@ func TestPubSubLogger(t *testing.T) {
 		for i := range value {
 			assert.Equal(t, expected[i], logrusLogLevelToKgoLogLevel(value[i]))
 		}
+	})
+}
+
+func TestPubSubLoggerLog(t *testing.T) {
+	t.Run("should return the proper log level", func(t *testing.T) {
+		value := []logrus.Level{
+			logrus.PanicLevel,
+			logrus.DebugLevel,
+			logrus.InfoLevel,
+			logrus.WarnLevel,
+			logrus.ErrorLevel,
+		}
+		expected := []kgo.LogLevel{
+			kgo.LogLevelError,
+			kgo.LogLevelDebug,
+			kgo.LogLevelInfo,
+			kgo.LogLevelWarn,
+			kgo.LogLevelError,
+		}
+		require.Equal(t, len(value), len(expected))
+		for i := range value {
+			l := getLogger()
+			l.Entry.Level = value[i]
+			l.Entry.Logger.Level = value[i]
+			psl := &pubsubLogger{l: l}
+			assert.Equal(t, expected[i].String(), psl.Level().String())
+		}
+	})
+
+	t.Run("should log the proper log level", func(t *testing.T) {
+		expected := []logrus.Level{
+			logrus.ErrorLevel,
+			logrus.DebugLevel,
+			logrus.InfoLevel,
+			logrus.WarnLevel,
+			logrus.TraceLevel,
+		}
+		value := []kgo.LogLevel{
+			kgo.LogLevelError,
+			kgo.LogLevelDebug,
+			kgo.LogLevelInfo,
+			kgo.LogLevelWarn,
+			kgo.LogLevelNone,
+		}
+		require.Equal(t, len(value), len(expected))
+		for i := range value {
+			l := getLogger()
+			l.Entry.Level = expected[i]
+			l.Entry.Logger.Level = expected[i]
+			h := test.NewLocal(l.Entry.Logger)
+			psl := &pubsubLogger{l: l}
+			psl.Log(value[i], "test_msg")
+			assert.Equal(t, 1, len(h.AllEntries()), "log level %s didn't log the right amount of time", value[i].String())
+			assert.Equal(t, expected[i].String(), h.AllEntries()[0].Level.String())
+		}
+	})
+
+	t.Run("should add the log fields when they are passed in", func(t *testing.T) {
+		l := getLogger()
+		h := test.NewLocal(l.Entry.Logger)
+		psl := &pubsubLogger{l: l}
+		psl.Log(kgo.LogLevelInfo, "test_msg", "test_key", "value", "test_key_with_interface", struct{}{})
+		le := h.LastEntry()
+		assert.Equal(t, "value", le.Data["pubsub.test_key"])
+		assert.Equal(t, struct{}{}, le.Data["pubsub.test_key_with_interface"])
+		assert.Equal(t, "test_msg", le.Message)
+		assert.Equal(t, logrus.InfoLevel, le.Level)
+	})
+
+	t.Run("should failed to add a field if the keyvals format is wrong (keyvals length)", func(t *testing.T) {
+		l := getLogger()
+		h := test.NewLocal(l.Entry.Logger)
+		psl := &pubsubLogger{l: l}
+		psl.Log(kgo.LogLevelInfo, "test_msg", "test_key", "value", "test_key_with_interface")
+		require.Equal(t, 2, len(h.AllEntries()))
+		assert.Contains(t, h.AllEntries()[0].Message, "failed to evaluate keyvals as the vals count is odd (3)")
+		assert.Equal(t, logrus.ErrorLevel, h.AllEntries()[0].Level)
+		assert.Equal(t, "test_msg", h.AllEntries()[1].Message)
+		assert.Equal(t, logrus.InfoLevel, h.AllEntries()[1].Level)
+	})
+
+	t.Run("should failed to add a field if the keyvals format is wrong (key type wrong)", func(t *testing.T) {
+		l := getLogger()
+		h := test.NewLocal(l.Entry.Logger)
+		psl := &pubsubLogger{l: l}
+		psl.Log(kgo.LogLevelInfo, "test_msg", struct{}{}, "value")
+		require.Equal(t, 2, len(h.AllEntries()))
+		assert.Contains(t, h.AllEntries()[0].Message, "key is not a string type for kgo keyval pair, unable to add field key")
+		assert.Equal(t, logrus.ErrorLevel, h.AllEntries()[0].Level)
+		assert.Equal(t, "test_msg", h.AllEntries()[1].Message)
+		assert.Equal(t, logrus.InfoLevel, h.AllEntries()[1].Level)
 	})
 }

--- a/pubsubx/kgox/test_helper.go
+++ b/pubsubx/kgox/test_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -151,4 +152,10 @@ func getPoisonQueueHandler(t *testing.T, l *logrusx.Logger, conf *pubsubx.Config
 	require.NoError(t, err)
 
 	return pubSub.PoisonQueueHandler().(*poisonQueueHandler)
+}
+
+func getLogger() *logrusx.Logger {
+	l := logrusx.New("Clinia x", "testing")
+	l.Entry.Logger.SetOutput(io.Discard)
+	return l
 }


### PR DESCRIPTION
This allows kgo to log using the same log level as the logrusx logger. This adds useful debugging information on failure and on connection.
Example :
```
INFO[2025-01-13T15:08:02-05:00] immediate metadata update triggered           audience=application pubsub.why=querying metadata for consumer initialization service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] immediate metadata update triggered           audience=application pubsub.why=forced load because we are producing to a topic for the first time service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] producing to a new topic for the first time, fetching metadata to learn its partitions  audience=application pubsub.topic=demo-test.test-topic1 service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] done waiting for metadata for new topic       audience=application pubsub.topic=demo-test.test-topic1 service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] beginning to manage the group lifecycle       audience=application pubsub.group=demo-test.test-group service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] joining group                                 audience=application pubsub.group=demo-test.test-group service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] initializing producer id                      audience=application service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] producer id initialization success            audience=application pubsub.epoch=0 pubsub.id=1002 service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] join returned MemberIDRequired, rejoining with response's MemberID  audience=application pubsub.group=demo-test.test-group pubsub.member_id=kgo-535b270b-0bbf-4ead-9033-f8e89f6f4cc7 service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] joined, balancing group                       audience=application pubsub.balance_protocol=cooperative-sticky pubsub.generation=5 pubsub.group=demo-test.test-group pubsub.instance_id=<nil> pubsub.leader=true pubsub.member_id=kgo-535b270b-0bbf-4ead-9033-f8e89f6f4cc7 service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] balancing group as leader                     audience=application service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] balance group member                          audience=application pubsub.id=kgo-535b270b-0bbf-4ead-9033-f8e89f6f4cc7 pubsub.interests=interested topics: [demo-test.test-topic1], previously owned:  service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] balanced                                      audience=application pubsub.plan=kgo-535b270b-0bbf-4ead-9033-f8e89f6f4cc7{demo-test.test-topic1[0]} service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] syncing                                       audience=application pubsub.group=demo-test.test-group pubsub.protocol=cooperative-sticky pubsub.protocol_type=consumer service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] synced                                        audience=application pubsub.assigned=demo-test.test-topic1[0] pubsub.group=demo-test.test-group service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] new group session begun                       audience=application pubsub.added=demo-test.test-topic1[0] pubsub.group=demo-test.test-group pubsub.lost= service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] beginning heartbeat loop                      audience=application pubsub.group=demo-test.test-group service_name=test service_version=v1
INFO[2025-01-13T15:08:02-05:00] assigning partitions                          audience=application pubsub.how=assigning everything new, keeping current assignment pubsub.input=demo-test.test-topic1[0{2 e1 ce0}] pubsub.why=newly fetched offsets for group demo-test.test-group service_name=test service_version=v1
```
