### PR TITLE
fix: [ENG-2688] Delete topics

### DIFF
--- a/pubsubx/admin_client.go
+++ b/pubsubx/admin_client.go
@@ -14,8 +14,6 @@ type PubSubAdminClient interface {
 	// CreateTopics creates a topics with the given configuration.
 	// The default configuration entries are set by default, but they can be overridden (see `pubsub.NewCreateTopicConfigEntries()`).
 	CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, topics []string, configs ...map[string]*string) (kadm.CreateTopicResponses, error)
-	// DeleteTopic deletes a topic.
-	DeleteTopic(ctx context.Context, topic string) (kadm.DeleteTopicResponse, error)
 	// DeleteTopicsWithRetryTopics deletes the topics with their related retry topics.
 	DeleteTopicsWithRetryTopics(ctx context.Context, topics ...string) (kadm.DeleteTopicResponses, error)
 	// DeleteTopicWithRetryTopics deletes a topic with it's related retry topics.

--- a/pubsubx/inmemory/noop_admin_client.go
+++ b/pubsubx/inmemory/noop_admin_client.go
@@ -76,14 +76,6 @@ func (n *NoopAdminClient) CreateTopics(ctx context.Context, partitions int32, re
 	return res, nil
 }
 
-// DeleteTopic implements pubsubx.PubSubAdminClient.
-func (n *NoopAdminClient) DeleteTopic(ctx context.Context, topic string) (kadm.DeleteTopicResponse, error) {
-	delete(n.topics, topic)
-	return kadm.DeleteTopicResponse{
-		Topic: topic,
-	}, nil
-}
-
 func (n *NoopAdminClient) DeleteTopicsWithRetryTopics(ctx context.Context, topics ...string) (kadm.DeleteTopicResponses, error) {
 	res := make(kadm.DeleteTopicResponses)
 	for _, t := range topics {

--- a/pubsubx/kgox/consumer.go
+++ b/pubsubx/kgox/consumer.go
@@ -238,6 +238,10 @@ func (c *consumer) handleTopic(ctx context.Context, tp kgo.FetchTopic) error {
 		return errorx.InternalErrorf("no handler for topic")
 	}
 	records := tp.Records()
+	if len(records) == 0 {
+		l.Debugf("no records to process")
+		return nil
+	}
 	go func() {
 		if c.consumerMetric != nil {
 			mtc := metric.WithAttributes(attribute.String("topic", tp.Topic))

--- a/pubsubx/kgox/event_retry_handler_test.go
+++ b/pubsubx/kgox/event_retry_handler_test.go
@@ -23,7 +23,7 @@ func TestGenerateRetryTopics(t *testing.T) {
 			cl, err := erh.AdminClient()
 			require.NoError(t, err)
 			for _, rt := range retryTopics {
-				cl.DeleteTopic(context.Background(), rt.TopicName(config.Scope))
+				cl.DeleteTopicWithRetryTopics(context.Background(), rt.TopicName(config.Scope))
 			}
 			cl.Close()
 		}()
@@ -46,7 +46,7 @@ func TestGenerateRetryTopics(t *testing.T) {
 		retryTopics, errs, err := erh.generateRetryTopics(context.Background(), topics...)
 		defer func() {
 			for _, rt := range retryTopics {
-				cl.DeleteTopic(context.Background(), rt.TopicName(config.Scope))
+				cl.DeleteTopicWithRetryTopics(context.Background(), rt.TopicName(config.Scope))
 			}
 			cl.Close()
 		}()
@@ -67,7 +67,7 @@ func TestGenerateRetryTopics(t *testing.T) {
 			cl, err := erh.AdminClient()
 			require.NoError(t, err)
 			for _, rt := range retryTopics {
-				cl.DeleteTopic(context.Background(), rt.TopicName(config.Scope))
+				cl.DeleteTopicWithRetryTopics(context.Background(), rt.TopicName(config.Scope))
 			}
 			cl.Close()
 		}()

--- a/pubsubx/kgox/poison_queue_handler_test.go
+++ b/pubsubx/kgox/poison_queue_handler_test.go
@@ -405,7 +405,7 @@ func TestConsumeQueue(t *testing.T) {
 			// Delete the topic
 			psub := (*PubSub)(pqh)
 			admin, _ := psub.AdminClient()
-			admin.DeleteTopic(context.Background(), pqTopic)
+			admin.DeleteTopicWithRetryTopics(context.Background(), pqTopic)
 		})
 		cctx, cancel := context.WithCancel(tctx)
 		defer cancel()
@@ -444,7 +444,7 @@ func TestConsumeQueue(t *testing.T) {
 			// Delete the topic
 			psub := (*PubSub)(pqh)
 			admin, _ := psub.AdminClient()
-			admin.DeleteTopic(context.Background(), pqTopic)
+			admin.DeleteTopicWithRetryTopics(context.Background(), pqTopic)
 		})
 		cctx, cancel := context.WithCancel(tctx)
 		defer cancel()

--- a/pubsubx/messagex/topic.go
+++ b/pubsubx/messagex/topic.go
@@ -1,7 +1,6 @@
 package messagex
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -13,10 +12,6 @@ const (
 )
 
 func NewTopic(topic string) (Topic, error) {
-	if strings.Contains(string(topic), TopicSeparator) {
-		return "", fmt.Errorf("topic name cannot contain '.'")
-	}
-
 	return Topic(topic), nil
 }
 

--- a/pubsubx/messagex/topic_test.go
+++ b/pubsubx/messagex/topic_test.go
@@ -14,10 +14,10 @@ func TestNewTopic(t *testing.T) {
 		assert.Equal(t, "my-topic", string(topic))
 	})
 
-	t.Run("should return error with invalid topic name", func(t *testing.T) {
+	t.Run("should not return error when topic contains dots", func(t *testing.T) {
 		topic, err := NewTopic("my" + TopicSeparator + "topic")
-		assert.Error(t, err)
-		assert.Equal(t, Topic(""), topic)
+		assert.NoError(t, err)
+		assert.Equal(t, Topic("my.topic"), topic)
 	})
 }
 
@@ -91,5 +91,15 @@ func TestBaseTopicFromName(t *testing.T) {
 	t.Run("should return an empty topic extracted from a retry suffix only topic", func(t *testing.T) {
 		topic := BaseTopicFromName("consumer-group" + TopicRetrySuffix)
 		assert.Equal(t, Topic(""), topic)
+	})
+
+	t.Run("should return the original topic name when it contains dots", func(t *testing.T) {
+		topic := BaseTopicFromName("scope.my-topic.interestingly.long")
+		assert.Equal(t, Topic("my-topic.interestingly.long"), topic)
+	})
+
+	t.Run("should return the original topic name when it contains dots with retry suffix", func(t *testing.T) {
+		topic := BaseTopicFromName("scope.my-topic.interestingly.long.consumer-group" + TopicRetrySuffix)
+		assert.Equal(t, Topic("my-topic.interestingly.long"), topic)
 	})
 }


### PR DESCRIPTION
Removes the error-prone `DeleteTopic` and fix the topic name validation that does not respect our current patterns.