### PR TITLE
feat: [ENG-2610] Adds the MessageReferenceTracer

### DIFF
--- a/pubsubx/messagex/reference_tracer.go
+++ b/pubsubx/messagex/reference_tracer.go
@@ -1,0 +1,36 @@
+package messagex
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type MessageReferenceTracer interface {
+	Message() *Message
+	ReferenceMsgSpanName() string
+
+	// StartMessageProcessingSpan starts a new span with a bidirectional link with
+	// the original span associated with the creation of the provided Message.
+	//
+	// For the created span, a link will be added pointing to the original message's span.
+	// For the original message's span, a subspan will be created with `${msgReferenceSpanName}`
+	// which links back to the current span. If `msgReferenceSpanName` is empty, the default
+	// name "async processing reference" will be used.
+	//
+	// This function should be called for any asynchronous processing of the message to enable
+	// advanced tracing and provide a clear view of the message's lifecycle and its associated
+	// operations.
+	StartMessageProcessingSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span)
+	// AttachMessageProcessingSpan creates a bidirectional link between the current span
+	// and the original span associated with the creation of the provided Message.
+	// This is useful when the original message's span is already created and you want to
+	// attach the current span to it.
+	//
+	// This function should be called for any asynchronous processing of the message to enable
+	// advanced tracing and provide a clear view of the message's lifecycle and its associated
+	// operations.
+	AttachMessageProcessingSpan(ctx context.Context, span trace.Span)
+
+	recordReferenceSpan(originalMsgContext context.Context, span trace.Span)
+}

--- a/pubsubx/messagex/reference_tracer_impl.go
+++ b/pubsubx/messagex/reference_tracer_impl.go
@@ -1,0 +1,80 @@
+package messagex
+
+import (
+	"context"
+
+	"github.com/clinia/x/errorx"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type messageReferenceTracer struct {
+	msg                  *Message
+	referenceMsgSpanName string
+	tr                   trace.Tracer
+}
+
+var _ MessageReferenceTracer = (*messageReferenceTracer)(nil)
+
+func NewMessageReferenceTracer(msg *Message, referenceMsgSpanName string, tr trace.Tracer) (MessageReferenceTracer, error) {
+	if msg == nil {
+		return nil, errorx.InternalErrorf("message cannot be nil")
+	}
+
+	if tr == nil {
+		return nil, errorx.InternalErrorf("tracer cannot be nil")
+	}
+
+	return messageReferenceTracer{
+		msg:                  msg,
+		referenceMsgSpanName: referenceMsgSpanName,
+		tr:                   tr,
+	}, nil
+}
+
+// AttachMessageProcessingSpan implements MessageReferenceTracer.
+func (m messageReferenceTracer) AttachMessageProcessingSpan(ctx context.Context, span trace.Span) {
+	originalMsgCtx := context.Background()
+	originalMsgCtx = m.Message().ExtractTraceContext(originalMsgCtx)
+
+	span.AddLink(trace.LinkFromContext(originalMsgCtx))
+	m.recordReferenceSpan(originalMsgCtx, span)
+}
+
+// StartMessageProcessingSpan implements MessageReferenceTracer.
+func (m messageReferenceTracer) StartMessageProcessingSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	originalMsgCtx := context.Background()
+	topts := opts
+	originalMsgCtx = m.Message().ExtractTraceContext(originalMsgCtx)
+	topts = append(opts, trace.WithLinks(
+		trace.LinkFromContext(originalMsgCtx),
+	))
+
+	ctx, currentSpan := m.tr.Start(ctx, name, topts...)
+
+	m.recordReferenceSpan(originalMsgCtx, currentSpan)
+
+	return ctx, currentSpan
+}
+
+// recordReferenceSpan implements MessageReferenceTracer.
+func (m messageReferenceTracer) recordReferenceSpan(originalMsgCtx context.Context, currentSpan trace.Span) {
+	refSpanName := m.ReferenceMsgSpanName()
+	if refSpanName == "" {
+		refSpanName = "async processing reference"
+	}
+
+	_, refSpan := m.tr.Start(originalMsgCtx, refSpanName, trace.WithLinks(trace.Link{
+		SpanContext: currentSpan.SpanContext(),
+	}))
+	refSpan.End()
+}
+
+// Message implements MessageReferenceTracerInfo.
+func (m messageReferenceTracer) Message() *Message {
+	return m.msg
+}
+
+// ReferenceMsgSpanName implements MessageReferenceTracerInfo.
+func (m messageReferenceTracer) ReferenceMsgSpanName() string {
+	return m.referenceMsgSpanName
+}


### PR DESCRIPTION
This PR adds the `messagex.MessageReferenceTracer` that will allow referential tracing with an original message trace.