### PR TITLE
chore: [ENG-3107] Add configx ability to disable file watching

### DIFF
--- a/configx/options.go
+++ b/configx/options.go
@@ -62,6 +62,12 @@ func SkipValidation() OptionModifier {
 	}
 }
 
+func DisableFileWatching() OptionModifier {
+	return func(p *Provider) {
+		p.disableFileWatching = true
+	}
+}
+
 func DisableEnvLoading() OptionModifier {
 	return func(p *Provider) {
 		p.disableEnvLoading = true


### PR DESCRIPTION
This pull request introduces a new option to allow disabling file watching in the `configx` package.
Very straight-forward.