### PR TITLE
feat: [AT-33] update Elasticsearch and Kibana images to latest versions; add Scroll method to Engine interface and implementation with tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         ports:
           - 8529/tcp
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.17.6
         env:
           discovery.type: single-node
           node.name: es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   arangodb:
     image: arangodb/arangodb:3.11.1
@@ -9,7 +7,7 @@ services:
       - "8529:8529"
   
   elasticsearch:
-    image: elasticsearch:8.14.3
+    image: elasticsearch:8.17.6
     environment:
       - node.name=es
       - cluster.name=docker-cluster
@@ -20,7 +18,7 @@ services:
       - '9200:9200'
 
   kibana:
-    image: kibana:8.14.3
+    image: kibana:8.17.6
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     ports:

--- a/elasticx/engine.go
+++ b/elasticx/engine.go
@@ -8,6 +8,7 @@ import (
 	elasticxsearch "github.com/clinia/x/elasticx/search"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/bulk"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/msearch"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/core/scroll"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 )
@@ -29,6 +30,9 @@ type Engine interface {
 
 	// Search performs a search request to Elastic Search
 	Search(ctx context.Context, query *search.Request, indices []string, opts ...elasticxsearch.Option) (*search.Response, error)
+
+	// Scroll performs a scroll request to Elastic Search
+	Scroll(ctx context.Context, req *scroll.Request) (*scroll.Response, error)
 
 	// MultiSearch performs a multi search request to Elastic Search
 	MultiSearch(ctx context.Context, items []elasticxmsearch.Item, opts ...elasticxmsearch.Option) (*msearch.Response, error)


### PR DESCRIPTION
This PR inmplements the elastic scroll endpoint as part of our engine interface. It is a simple endpoint without much business logic. Essentially proxying the method to es client.